### PR TITLE
Add support for libs and dropins copying

### DIFF
--- a/dockerfiles/is/Dockerfile
+++ b/dockerfiles/is/Dockerfile
@@ -71,6 +71,8 @@ RUN unzip -q ${USER_HOME}/${WSO2_SERVER_PACK} -d ${USER_HOME}/ \
     && mkdir -p ${USER_HOME}/tmp \
     && cp -r ${USER_HOME}/${WSO2_SERVER}-${WSO2_SERVER_VERSION}/repository/deployment/server ${USER_HOME}/tmp/ \
     && mkdir -p ${JAVA_HOME} \
+    && mkdir -p ${USER_HOME}/${WSO2_SERVER}-${WSO2_SERVER_VERSION}-lib \
+    && mkdir -p ${USER_HOME}/${WSO2_SERVER}-${WSO2_SERVER_VERSION}-dropins \
     && tar -xf ${USER_HOME}/${JDK_ARCHIVE} -C ${JAVA_HOME} --strip-components=1 \
     && cp ${USER_HOME}/${JDBC_DRIVER} ${USER_HOME}/${DNS_JAVA_LIB} ${WSO2_SERVER_HOME}/repository/components/lib/ \
     && cp ${USER_HOME}/${KUBERNETES_MEMBERSHIP_SCHEME_LIB} ${WSO2_SERVER_HOME}/repository/components/dropins/ \

--- a/dockerfiles/is/change_ownership.sh
+++ b/dockerfiles/is/change_ownership.sh
@@ -18,7 +18,7 @@
 
 set -e
 
-echo 'going to change ownership of <IS_HOME>/repository/data directory: '
+echo 'going to change ownership of <IS_HOME>/repository/deployment/server directory: '
 echo "user: ${USER}"
 echo "user home: ${USER_HOME}"
 echo "carbon server: ${WSO2_SERVER}-${WSO2_SERVER_VERSION}"

--- a/dockerfiles/is/init_carbon.sh
+++ b/dockerfiles/is/init_carbon.sh
@@ -61,6 +61,13 @@ if [ -e ${carbon_home}-conf/conf-tomcat ]
  then cp ${carbon_home}-conf/conf-tomcat/* ${carbon_home}/repository/conf/tomcat/
 fi
 
+if [ -n "$(ls -A ${carbon_home}-lib 2>/dev/null)" ]
+ then cp ${carbon_home}-lib/* ${carbon_home}/repository/components/lib/
+fi
+
+if [ -n "$(ls -A ${carbon_home}-dropins 2>/dev/null)" ]
+ then cp ${carbon_home}-dropins/* ${carbon_home}/repository/components/dropins/
+fi
 
 # overwrite localMemberHost element value in axis2.xml with container ip
 export local_docker_ip=$(ip route get 1 | awk '{print $NF;exit}')


### PR DESCRIPTION
## Purpose
This PR add support for copying files to dropins and lib folder to the default distribution. If there are any files in /home/wso2user/wso2is-5.5.0-lib or /home/wso2user/wso2is-5.5.0-dropins folder, those files will be copied to repository/components/lib and repository/components/dropins folder respectively.

## Goals
Provide support for adding customizations through lib and dropins folder.

## Approach
N/A

## User stories
N/A

## Release note
Add support for copying customized jars to libs and dropins folder

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A