### PR TITLE
Ignore imagePullCredentials when using public docker images

### DIFF
--- a/advanced/helm/is-with-analytics/is-with-analytics/templates/identity-server-analytics-dashboard-deployment.yaml
+++ b/advanced/helm/is-with-analytics/is-with-analytics/templates/identity-server-analytics-dashboard-deployment.yaml
@@ -57,3 +57,7 @@ spec:
         configMap:
           name: is-analytics-dashboard-conf
       serviceAccountName: "wso2svc-account"
+      {{ if and (not (eq .Values.username "")) (not (eq .Values.password "")) }}
+      imagePullSecrets:
+      - name: wso2creds
+      {{ end }}

--- a/advanced/helm/is-with-analytics/is-with-analytics/templates/identity-server-analytics-worker-deployment.yaml
+++ b/advanced/helm/is-with-analytics/is-with-analytics/templates/identity-server-analytics-worker-deployment.yaml
@@ -106,6 +106,10 @@ spec:
         - name: is-analytics-worker-conf
           mountPath: /home/wso2carbon/wso2-config-volume/conf/worker
       serviceAccountName: "wso2svc-account"
+      {{ if and (not (eq .Values.username "")) (not (eq .Values.password "")) }}
+      imagePullSecrets:
+      - name: wso2creds
+      {{ end }}
       volumes:
       - name: is-analytics-worker-conf
         configMap:

--- a/advanced/helm/is-with-analytics/is-with-analytics/templates/identity-server-deployment.yaml
+++ b/advanced/helm/is-with-analytics/is-with-analytics/templates/identity-server-deployment.yaml
@@ -84,6 +84,10 @@ spec:
         - name: shared-tenants-persistent-disk
           mountPath: /home/wso2carbon/wso2is-5.8.0/repository/tenants
       serviceAccountName: "wso2svc-account"
+      {{ if and (not (eq .Values.username "")) (not (eq .Values.password "")) }}
+      imagePullSecrets:
+      - name: wso2creds
+      {{ end }}
       volumes:
       - name: identity-server-conf
         configMap:

--- a/advanced/helm/is/is/templates/identity-server-deployment.yaml
+++ b/advanced/helm/is/is/templates/identity-server-deployment.yaml
@@ -79,6 +79,10 @@ spec:
         - name: shared-tenants-persistent-disk
           mountPath: /home/wso2carbon/wso2is-5.8.0/repository/tenants
       serviceAccountName: {{ .Values.svcaccount }}
+      {{ if and (not (eq .Values.username "")) (not (eq .Values.password "")) }}
+      imagePullSecrets:
+      - name: wso2creds
+      {{ end }}
       volumes:
       - name: identity-server-conf
         configMap:


### PR DESCRIPTION
## Purpose
Add conditional use of imagePullCredentials when using WSO2 private docker registry in helm charts.
