### PR TITLE
Adding option to use image with no tag when using third party registry

### DIFF
--- a/advanced/helm/is-pattern-1/templates/identity-server-deployment.yaml
+++ b/advanced/helm/is-pattern-1/templates/identity-server-deployment.yaml
@@ -55,8 +55,10 @@ spec:
       {{ end }}
       containers:
       - name: wso2is
-        {{ if .Values.wso2.dockerRegistry }}
-        image: {{ .Values.wso2.dockerRegistry }}/{{ default "wso2is" .Values.wso2.deployment.wso2is.imageName }}:{{ default "5.8.0" .Values.wso2.deployment.wso2is.imageTag }}
+        {{ if .Values.wso2.deployment.wso2is.dockerRegistry }}
+        image: {{ .Values.wso2.deployment.wso2is.dockerRegistry }}/{{ default "wso2is" .Values.wso2.deployment.wso2is.imageName }}
+        {{- $tag := .Values.wso2.deployment.wso2is.imageTag }}
+        {{- if not (eq $tag "") }}{{- printf ":%s" $tag -}}{{- end }}
         {{ else if or (eq .Values.wso2.subscription.username "") (eq .Values.wso2.subscription.password "") }}
         image: wso2/{{ default "wso2is" .Values.wso2.deployment.wso2is.imageName }}:{{ default "5.8.0" .Values.wso2.deployment.wso2is.imageTag }}
         {{ else }}

--- a/advanced/helm/is-pattern-2/templates/identity-server-analytics-dashboard-deployment.yaml
+++ b/advanced/helm/is-pattern-2/templates/identity-server-analytics-dashboard-deployment.yaml
@@ -54,8 +54,10 @@ spec:
       {{ end }}
       containers:
       - name: wso2is-with-analytics-is-analytics-dashboard
-        {{- if .Values.wso2.dockerRegistry }}
-        image: {{ .Values.wso2.dockerRegistry }}/{{ default "wso2is-analytics-dashboard" .Values.wso2.deployment.wso2isAnalyticsDashboard.imageName }}:{{ default "5.8.0" .Values.wso2.deployment.wso2isAnalyticsDashboard.imageTag }}
+        {{- if .Values.wso2.deployment.wso2isAnalyticsDashboard.dockerRegistry }}
+        image: {{ .Values.wso2.deployment.wso2isAnalyticsDashboard.dockerRegistry }}/{{ default "wso2is-analytics-dashboard" .Values.wso2.deployment.wso2isAnalyticsDashboard.imageName }}
+        {{- $tag := .Values.wso2.deployment.wso2isAnalyticsDashboard.imageTag }}
+        {{- if not (eq $tag "") }}{{- printf ":%s" $tag -}}{{- end }}
         {{- else if or (eq .Values.wso2.subscription.username "") (eq .Values.wso2.subscription.password "") }}
         image: wso2/{{ default "wso2is-analytics-dashboard" .Values.wso2.deployment.wso2isAnalyticsDashboard.imageName }}:{{ default "5.8.0" .Values.wso2.deployment.wso2isAnalyticsDashboard.imageTag }}
         {{- else }}

--- a/advanced/helm/is-pattern-2/templates/identity-server-analytics-worker-deployment.yaml
+++ b/advanced/helm/is-pattern-2/templates/identity-server-analytics-worker-deployment.yaml
@@ -54,8 +54,10 @@ spec:
       {{ end }}
       containers:
       - name: wso2is-with-analytics-is-analytics-worker
-        {{- if .Values.wso2.dockerRegistry }}
-        image: {{ .Values.wso2.dockerRegistry }}/{{ default "wso2is-analytics-worker" .Values.wso2.deployment.wso2isAnalyticsWorker.imageName }}:{{ default "5.8.0" .Values.wso2.deployment.wso2isAnalyticsWorker.imageTag }}
+        {{- if .Values.wso2.deployment.wso2isAnalyticsWorker.dockerRegistry }}
+        image: {{ .Values.wso2.deployment.wso2isAnalyticsWorker.dockerRegistry }}/{{ default "wso2is-analytics-worker" .Values.wso2.deployment.wso2isAnalyticsWorker.imageName }}
+        {{- $tag := .Values.wso2.deployment.wso2isAnalyticsWorker.imageTag }}
+        {{- if not (eq $tag "") }}{{- printf ":%s" $tag -}}{{- end }}
         {{- else if or (eq .Values.wso2.subscription.username "") (eq .Values.wso2.subscription.password "") }}
         image: wso2/{{ default "wso2is-analytics-worker" .Values.wso2.deployment.wso2isAnalyticsWorker.imageName }}:{{ default "5.8.0" .Values.wso2.deployment.wso2isAnalyticsWorker.imageTag }}
         {{- else }}

--- a/advanced/helm/is-pattern-2/templates/identity-server-deployment.yaml
+++ b/advanced/helm/is-pattern-2/templates/identity-server-deployment.yaml
@@ -55,8 +55,10 @@ spec:
       {{ end }}
       containers:
       - name: wso2is
-        {{ if .Values.wso2.dockerRegistry }}
-        image: {{ .Values.wso2.dockerRegistry }}/{{ default "wso2is" .Values.wso2.deployment.wso2is.imageName }}:{{ default "5.8.0" .Values.wso2.deployment.wso2is.imageTag }}
+        {{ if .Values.wso2.deployment.wso2is.dockerRegistry }}
+        image: {{ .Values.wso2.deployment.wso2is.dockerRegistry }}/{{ default "wso2is" .Values.wso2.deployment.wso2is.imageName }}
+        {{- $tag := .Values.wso2.deployment.wso2is.imageTag }}
+        {{- if not (eq $tag "") }}{{- printf ":%s" $tag -}}{{- end }}
         {{ else if or (eq .Values.wso2.subscription.username "") (eq .Values.wso2.subscription.password "") }}
         image: wso2/{{ default "wso2is" .Values.wso2.deployment.wso2is.imageName }}:{{ default "5.8.0" .Values.wso2.deployment.wso2is.imageTag }}
         {{ else }}


### PR DESCRIPTION
## Purpose
- It should be possible to choose if each image is using a third party docker registry rather than deciding as a whole. This way I would be able to use wso2 images while using an image from a private registry for one deployment.
- I should be able to use an image name without a tag since configuring spinnaker requires not having the tag.