### PR TITLE
Parameterize secrets for each deployment

### DIFF
--- a/advanced/helm/is-pattern-1/requirements.yaml
+++ b/advanced/helm/is-pattern-1/requirements.yaml
@@ -13,6 +13,6 @@
 # limitations under the License.
 dependencies:
   - name: mysql-is
-    version: "5.8.0-1"
+    version: "5.8.0-3"
     repository: "https://helm.wso2.com"
     condition: wso2.mysql.enabled

--- a/advanced/helm/is-pattern-1/templates/identity-server-deployment.yaml
+++ b/advanced/helm/is-pattern-1/templates/identity-server-deployment.yaml
@@ -160,7 +160,10 @@ spec:
             value: {{ default "wso2-elasticsearch-master" .Values.wso2.centralizedLogging.logstash.elasticsearch.host }}
       {{ end }}
       serviceAccountName: {{ .Values.kubernetes.svcaccount }}
-      {{ if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
+      {{- if .Values.wso2.deployment.wso2is.imagePullSecrets }}
+      imagePullSecrets:
+      - name: {{ .Values.wso2.deployment.wso2is.imagePullSecrets }}
+      {{- else if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
       imagePullSecrets:
         - name: wso2is-deployment-creds
       {{ end }}

--- a/advanced/helm/is-pattern-2/requirements.yaml
+++ b/advanced/helm/is-pattern-2/requirements.yaml
@@ -13,6 +13,6 @@
 # limitations under the License.
 dependencies:
   - name: mysql-is
-    version: "5.8.0-1"
+    version: "5.8.0-3"
     repository: "https://helm.wso2.com"
     condition: wso2.mysql.enabled

--- a/advanced/helm/is-pattern-2/templates/identity-server-analytics-dashboard-deployment.yaml
+++ b/advanced/helm/is-pattern-2/templates/identity-server-analytics-dashboard-deployment.yaml
@@ -123,7 +123,10 @@ spec:
             value: {{ default "wso2-elasticsearch-master" .Values.wso2.centralizedLogging.logstash.elasticsearch.host }}
       {{ end }}
       serviceAccountName: {{ .Values.kubernetes.svcaccount }}
-      {{ if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
+      {{- if .Values.wso2.deployment.wso2isAnalyticsDashboard.imagePullSecrets }}
+      imagePullSecrets:
+      - name: {{ .Values.wso2.deployment.wso2isAnalyticsDashboard.imagePullSecrets }}
+      {{- else if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
       imagePullSecrets:
       - name: wso2creds
       {{ end }}

--- a/advanced/helm/is-pattern-2/templates/identity-server-analytics-worker-deployment.yaml
+++ b/advanced/helm/is-pattern-2/templates/identity-server-analytics-worker-deployment.yaml
@@ -173,7 +173,10 @@ spec:
             value: {{ default "wso2-elasticsearch-master" .Values.wso2.centralizedLogging.logstash.elasticsearch.host }}
       {{ end }}
       serviceAccountName: {{ .Values.kubernetes.svcaccount }}
-      {{ if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
+      {{- if .Values.wso2.deployment.wso2isAnalyticsWorker.imagePullSecrets }}
+      imagePullSecrets:
+      - name: {{ .Values.wso2.deployment.wso2isAnalyticsWorker.imagePullSecrets }}
+      {{- else if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
       imagePullSecrets:
       - name: wso2creds
       {{ end }}

--- a/advanced/helm/is-pattern-2/templates/identity-server-deployment.yaml
+++ b/advanced/helm/is-pattern-2/templates/identity-server-deployment.yaml
@@ -166,10 +166,13 @@ spec:
             value: {{ default "wso2-elasticsearch-master" .Values.wso2.centralizedLogging.logstash.elasticsearch.host }}
       {{ end }}
       serviceAccountName: {{ .Values.kubernetes.svcaccount }}
-      {{ if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
+      {{- if .Values.wso2.deployment.wso2is.imagePullSecrets }}
+      imagePullSecrets:
+      - name: {{ .Values.wso2.deployment.wso2is.imagePullSecrets }}
+      {{- else if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
       imagePullSecrets:
       - name: wso2is-deployment-creds
-      {{ end }}
+      {{- end }}
       volumes:
       - name: identity-server-conf
         configMap:


### PR DESCRIPTION
## Purpose
When using the charts in CI/CD pipeline, not all images will come from one registry. Some might be from WSO2 docker registry while some might be from another private registry. Therefore it should be possible to plugin external secrets when pulling images from other registries.