### PR TITLE
Remove "wso2is" from ingress host name

### DIFF
--- a/advanced/helm/is-pattern-1/README.md
+++ b/advanced/helm/is-pattern-1/README.md
@@ -101,7 +101,7 @@ helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/is-pattern-1 --namespace
 
 ##### 4. Access Management Console.
 
-Default deployment will expose `<RELEASE_NAME>-wso2is` host (to expose Administrative services and Management Console).
+Default deployment will expose `<RELEASE_NAME>` host (to expose Administrative services and Management Console).
 
 To access the console in the environment,
 
@@ -113,13 +113,13 @@ kubectl get ing -n <NAMESPACE>
 
 ```
 NAME                       HOSTS                         ADDRESS        PORTS     AGE
-wso2is-ingress             <RELEASE_NAME>-wso2is         <EXTERNAL-IP>  80, 443   3m
+wso2is-ingress             <RELEASE_NAME>         <EXTERNAL-IP>  80, 443   3m
 ```
 
 b. Add the above host as an entry in /etc/hosts file as follows:
 
 ```
-<EXTERNAL-IP>	<RELEASE_NAME>-wso2is
+<EXTERNAL-IP>	<RELEASE_NAME>
 ```
 
-c. Try navigating to `https://<RELEASE_NAME>-wso2is/carbon` from your favorite browser.
+c. Try navigating to `https://<RELEASE_NAME>/carbon` from your favorite browser.

--- a/advanced/helm/is-pattern-1/templates/identity-server-ingress.yaml
+++ b/advanced/helm/is-pattern-1/templates/identity-server-ingress.yaml
@@ -26,9 +26,9 @@ metadata:
 spec:
   tls:
   - hosts:
-    - {{ .Release.Name }}-wso2is
+    - {{ .Release.Name }}
   rules:
-  - host: {{ .Release.Name }}-wso2is
+  - host: {{ .Release.Name }}
     http:
       paths:
       - path: /

--- a/advanced/helm/is-pattern-2/README.md
+++ b/advanced/helm/is-pattern-2/README.md
@@ -146,7 +146,7 @@ helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/is-pattern-2 --namespace
 
 ##### 4. Access Management Console.
 
-Default deployment will expose `<RELEASE_NAME>-wso2is` and `<RELEASE_NAME>-analytics-dashboard` hosts (to expose Administrative services and Management Console).
+Default deployment will expose `<RELEASE_NAME>` and `<RELEASE_NAME>-analytics-dashboard` hosts (to expose Administrative services and Management Console).
 
 To access the console in the environment,
 
@@ -159,15 +159,15 @@ kubectl get ing -n <NAMESPACE>
 ```
 NAME                                         HOSTS                                ADDRESS        PORTS     AGE
 wso2is-with-analytics-is-dashboard-ingress   <RELEASE_NAME>-analytics-dashboard   <EXTERNAL-IP>   80, 443   3m
-wso2is-with-analytics-is-ingress             <RELEASE_NAME>-wso2is                <EXTERNAL-IP>   80, 443   3m
+wso2is-with-analytics-is-ingress             <RELEASE_NAME>                       <EXTERNAL-IP>   80, 443   3m
 ``` 
 
 b. Add the above host as an entry in /etc/hosts file as follows:
 
 ```
 <EXTERNAL-IP>	<RELEASE_NAME>-analytics-dashboard
-<EXTERNAL-IP>	<RELEASE_NAME>-wso2is
+<EXTERNAL-IP>	<RELEASE_NAME>
 ```
 
-c. Try navigating to `https://<RELEASE_NAME>-wso2is/carbon` and `https://<RELEASE_NAME>-analytics-dashboard/portal` from your favorite browser.
+c. Try navigating to `https://<RELEASE_NAME>/carbon` and `https://<RELEASE_NAME>-analytics-dashboard/portal` from your favorite browser.
 

--- a/advanced/helm/is-pattern-2/templates/identity-server-ingress.yaml
+++ b/advanced/helm/is-pattern-2/templates/identity-server-ingress.yaml
@@ -26,9 +26,9 @@ metadata:
 spec:
   tls:
   - hosts:
-    - {{ .Release.Name }}-wso2is
+    - {{ .Release.Name }}
   rules:
-  - host: {{ .Release.Name }}-wso2is
+  - host: {{ .Release.Name }}
     http:
       paths:
       - path: /


### PR DESCRIPTION
## Purpose
Host name `<RELEASE_NAME>-wso2is` can be too long and confusing. Instead the release name itself could be used for the ingress host name.