### PR TITLE
Add Prometheus Monitoring support

### DIFF
--- a/advanced/helm/is-pattern-1/README.md
+++ b/advanced/helm/is-pattern-1/README.md
@@ -69,6 +69,15 @@ If you do not have active WSO2 subscription do not change the parameters `wso2.s
 | `wso2.centralizedLogging.logstash.elasticsearch.password`                   | Elasticsearch password                                                                    | changeme                    |  
 | `wso2.centralizedLogging.logstash.indexNodeID.wso2ISNode`                   | Elasticsearch IS Node log index ID(index name: ${NODE_ID}-${NODE_IP})                     | wso2                        |
 
+###### Monitoring Configurations
+
+| Parameter                                                                   | Description                                                                               | Default Value               |
+|-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|-----------------------------|
+| `wso2.monitoring.enabled`                                                   | Enable Prometheus monitoring                                                              | false                       |                                                                                         |                             |    
+| `wso2.monitoring.prometheus.serviceMonitor.labels`                          | Prometheus labels for identifying Service Monitor                                         | "release: monitoring"       |  
+| `wso2.monitoring.prometheus.blackBoxNamespace`                              | Prometheus blackbox exporter namespace                                                    | <RELEASE_NAMESPACE>         |  
+| `wso2.monitoring.prometheus.jmxJobName`                                     | Prometheus job name                                                                       | jmx                         | 
+
 ###### Identity Server Configurations
 
 | Parameter                                                                   | Description                                                                               | Default Value               |

--- a/advanced/helm/is-pattern-1/README.md
+++ b/advanced/helm/is-pattern-1/README.md
@@ -67,16 +67,15 @@ If you do not have active WSO2 subscription do not change the parameters `wso2.s
 | `wso2.centralizedLogging.logstash.imageTag`                                 | Logstash Sidecar container image tag                                                      | 7.2.0                       |  
 | `wso2.centralizedLogging.logstash.elasticsearch.username`                   | Elasticsearch username                                                                    | elastic                     |  
 | `wso2.centralizedLogging.logstash.elasticsearch.password`                   | Elasticsearch password                                                                    | changeme                    |  
-| `wso2.centralizedLogging.logstash.indexNodeID.wso2ISNode`                   | Elasticsearch IS Node log index ID(index name: ${NODE_ID}-${NODE_IP})                     | wso2                        |
 
 ###### Monitoring Configurations
 
 | Parameter                                                                   | Description                                                                               | Default Value               |
 |-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|-----------------------------|
 | `wso2.monitoring.enabled`                                                   | Enable Prometheus monitoring                                                              | false                       |                                                                                         |                             |    
-| `wso2.monitoring.prometheus.serviceMonitor.labels`                          | Prometheus labels for identifying Service Monitor                                         | "release: monitoring"       |  
 | `wso2.monitoring.prometheus.blackBoxNamespace`                              | Prometheus blackbox exporter namespace                                                    | <RELEASE_NAMESPACE>         |  
-| `wso2.monitoring.prometheus.jmxJobName`                                     | Prometheus job name                                                                       | jmx                         | 
+| `wso2.monitoring.prometheus.jmxJobName`                                     | Prometheus job name                                                                       | jmx                         |  
+| `wso2.monitoring.prometheus.serviceMonitor.labels`                          | Prometheus labels for identifying Service Monitor                                         | "release: monitoring"       |  
 
 ###### Identity Server Configurations
 

--- a/advanced/helm/is-pattern-1/confs/bin/wso2server.sh
+++ b/advanced/helm/is-pattern-1/confs/bin/wso2server.sh
@@ -1,0 +1,321 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+#  Copyright 2005-2012 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ----------------------------------------------------------------------------
+# Main Script for the WSO2 Carbon Server
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of WSO2 Carbon installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+#   JAVA_OPTS       (Optional) Java runtime options used when the commands
+#                   is executed.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+# -----------------------------------------------------------------------------
+
+# OS specific support.  $var _must_ be set to either true or false.
+#ulimit -n 100000
+
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# Set AXIS2_HOME. Needed for One Click JAR Download
+AXIS2_HOME="$CARBON_HOME"
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$AXIS2_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=java
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly."
+  echo " CARBON cannot execute $JAVACMD"
+  exit 1
+fi
+
+# if JAVA_HOME is not set we're not happy
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+if [ -e "$CARBON_HOME/wso2carbon.pid" ]; then
+  PID=`cat "$CARBON_HOME"/wso2carbon.pid`
+fi
+
+# ----- Process the input command ----------------------------------------------
+args=""
+for c in $*
+do
+    if [ "$c" = "--debug" ] || [ "$c" = "-debug" ] || [ "$c" = "debug" ]; then
+          CMD="--debug"
+          continue
+    elif [ "$CMD" = "--debug" ]; then
+          if [ -z "$PORT" ]; then
+                PORT=$c
+          fi
+    elif [ "$c" = "--stop" ] || [ "$c" = "-stop" ] || [ "$c" = "stop" ]; then
+          CMD="stop"
+    elif [ "$c" = "--start" ] || [ "$c" = "-start" ] || [ "$c" = "start" ]; then
+          CMD="start"
+    elif [ "$c" = "--version" ] || [ "$c" = "-version" ] || [ "$c" = "version" ]; then
+          CMD="version"
+    elif [ "$c" = "--restart" ] || [ "$c" = "-restart" ] || [ "$c" = "restart" ]; then
+          CMD="restart"
+    elif [ "$c" = "--test" ] || [ "$c" = "-test" ] || [ "$c" = "test" ]; then
+          CMD="test"
+    else
+        args="$args $c"
+    fi
+done
+
+if [ "$CMD" = "--debug" ]; then
+  if [ "$PORT" = "" ]; then
+    echo " Please specify the debug port after the --debug option"
+    exit 1
+  fi
+  if [ -n "$JAVA_OPTS" ]; then
+    echo "Warning !!!. User specified JAVA_OPTS will be ignored, once you give the --debug option."
+  fi
+  CMD="RUN"
+  JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=$PORT"
+  echo "Please start the remote debugging client to continue..."
+elif [ "$CMD" = "start" ]; then
+  if [ -e "$CARBON_HOME/wso2carbon.pid" ]; then
+    if  ps -p $PID > /dev/null ; then
+      echo "Process is already running"
+      exit 0
+    fi
+  fi
+  export CARBON_HOME="$CARBON_HOME"
+# using nohup sh to avoid erros in solaris OS.TODO
+  nohup sh "$CARBON_HOME"/bin/wso2server.sh $args > /dev/null 2>&1 &
+  exit 0
+elif [ "$CMD" = "stop" ]; then
+  export CARBON_HOME="$CARBON_HOME"
+  kill -term `cat "$CARBON_HOME"/wso2carbon.pid`
+  exit 0
+elif [ "$CMD" = "restart" ]; then
+  export CARBON_HOME="$CARBON_HOME"
+  kill -term `cat "$CARBON_HOME"/wso2carbon.pid`
+  process_status=0
+  pid=`cat "$CARBON_HOME"/wso2carbon.pid`
+  while [ "$process_status" -eq "0" ]
+  do
+        sleep 1;
+        ps -p$pid 2>&1 > /dev/null
+        process_status=$?
+  done
+
+# using nohup sh to avoid erros in solaris OS.TODO
+  nohup sh "$CARBON_HOME"/bin/wso2server.sh $args > /dev/null 2>&1 &
+  exit 0
+elif [ "$CMD" = "test" ]; then
+    JAVACMD="exec "$JAVACMD""
+elif [ "$CMD" = "version" ]; then
+  cat "$CARBON_HOME"/bin/version.txt
+  cat "$CARBON_HOME"/bin/wso2carbon-version.txt
+  exit 0
+fi
+
+# ---------- Handle the SSL Issue with proper JDK version --------------------
+jdk_17=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[7|8]"`
+if [ "$jdk_17" = "" ]; then
+   echo " Starting WSO2 Carbon (in unsupported JDK)"
+   echo " [ERROR] CARBON is supported only on JDK 1.7 and 1.8"
+fi
+
+CARBON_XBOOTCLASSPATH=""
+for f in "$CARBON_HOME"/lib/xboot/*.jar
+do
+    if [ "$f" != "$CARBON_HOME/lib/xboot/*.jar" ];then
+        CARBON_XBOOTCLASSPATH="$CARBON_XBOOTCLASSPATH":$f
+    fi
+done
+
+JAVA_ENDORSED_DIRS="$CARBON_HOME/lib/endorsed":"$JAVA_HOME/jre/lib/endorsed":"$JAVA_HOME/lib/endorsed"
+
+CARBON_CLASSPATH=""
+if [ -e "$JAVA_HOME/lib/tools.jar" ]; then
+    CARBON_CLASSPATH="$JAVA_HOME/lib/tools.jar"
+fi
+for f in "$CARBON_HOME"/bin/*.jar
+do
+    if [ "$f" != "$CARBON_HOME/bin/*.jar" ];then
+        CARBON_CLASSPATH="$CARBON_CLASSPATH":$f
+    fi
+done
+for t in "$CARBON_HOME"/lib/commons-lang*.jar
+do
+    CARBON_CLASSPATH="$CARBON_CLASSPATH":$t
+done
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  AXIS2_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+  CARBON_CLASSPATH=`cygpath --path --windows "$CARBON_CLASSPATH"`
+  CARBON_XBOOTCLASSPATH=`cygpath --path --windows "$CARBON_XBOOTCLASSPATH"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+echo JAVA_HOME environment variable is set to $JAVA_HOME
+echo CARBON_HOME environment variable is set to "$CARBON_HOME"
+
+cd "$CARBON_HOME"
+
+TMP_DIR="$CARBON_HOME"/tmp
+if [ -d "$TMP_DIR" ]; then
+rm -rf "$TMP_DIR"/*
+fi
+
+START_EXIT_STATUS=121
+status=$START_EXIT_STATUS
+
+if [ -z "$JVM_MEM_OPTS" ]; then
+   java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+   JVM_MEM_OPTS="-Xms256m -Xmx1024m"
+   if [ "$java_version" \< "1.8" ]; then
+      JVM_MEM_OPTS="$JVM_MEM_OPTS -XX:MaxPermSize=256m"
+   fi
+fi
+echo "Using Java memory options: $JVM_MEM_OPTS"
+
+#To monitor a Carbon server in remote JMX mode on linux host machines, set the below system property.
+#   -Djava.rmi.server.hostname="your.IP.goes.here"
+
+while [ "$status" = "$START_EXIT_STATUS" ]
+do
+    $JAVACMD \
+    -Xbootclasspath/a:"$CARBON_XBOOTCLASSPATH" \
+    $JVM_MEM_OPTS \
+    -XX:+HeapDumpOnOutOfMemoryError \
+    -XX:HeapDumpPath="$CARBON_HOME/repository/logs/heap-dump.hprof" \
+    $JAVA_OPTS \
+    -Dcom.sun.management.jmxremote \
+    -classpath "$CARBON_CLASSPATH" \
+    -Djava.endorsed.dirs="$JAVA_ENDORSED_DIRS" \
+    -Djava.io.tmpdir="$CARBON_HOME/tmp" \
+    -Dcatalina.base="$CARBON_HOME/lib/tomcat" \
+    -Dwso2.server.standalone=true \
+    -Dcarbon.registry.root=/ \
+    -Djava.command="$JAVACMD" \
+    -Dcarbon.home="$CARBON_HOME" \
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager \
+    -Dcarbon.config.dir.path="$CARBON_HOME/repository/conf" \
+    -Djava.util.logging.config.file="$CARBON_HOME/repository/conf/etc/logging-bridge.properties" \
+    -Dcomponents.repo="$CARBON_HOME/repository/components/plugins" \
+    -Dconf.location="$CARBON_HOME/repository/conf"\
+    -Dcom.atomikos.icatch.file="$CARBON_HOME/lib/transactions.properties" \
+    -Dcom.atomikos.icatch.hide_init_file_path=true \
+    -Dorg.apache.jasper.compiler.Parser.STRICT_QUOTE_ESCAPING=false \
+    -Dorg.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER=true \
+    -Dcom.sun.jndi.ldap.connect.pool.authentication=simple  \
+    -Dcom.sun.jndi.ldap.connect.pool.timeout=3000  \
+    -Dorg.terracotta.quartz.skipUpdateCheck=true \
+    -Djava.security.egd=file:/dev/./urandom \
+    -Dfile.encoding=UTF8 \
+    -Djava.net.preferIPv4Stack=true \
+    -Dcom.ibm.cacheLocalHost=true \
+    -DworkerNode=false \
+    -DenableCorrelationLogs=false \
+    -javaagent:/home/wso2carbon/prometheus/jmx_prometheus_javaagent-0.12.0.jar=2222:/home/wso2carbon/prometheus/config.yaml \
+    -Dorg.apache.xml.security.ignoreLineBreaks=false \
+    org.wso2.carbon.bootstrap.Bootstrap $*
+    status=$?
+done

--- a/advanced/helm/is-pattern-1/templates/_helpers.tpl
+++ b/advanced/helm/is-pattern-1/templates/_helpers.tpl
@@ -15,7 +15,7 @@ limitations under the License.
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "is-with-analytics-conf.name" -}}
+{{- define "is-pattern-1.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -24,7 +24,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "is-with-analytics-conf.fullname" -}}
+{{- define "is-pattern-1.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -40,7 +40,7 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "is-with-analytics-conf.chart" -}}
+{{- define "is-pattern-1.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 

--- a/advanced/helm/is-pattern-1/templates/is/identity-server-bin.yaml
+++ b/advanced/helm/is-pattern-1/templates/is/identity-server-bin.yaml
@@ -11,18 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-{{ if .Values.wso2.monitoring.enabled }}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
-    name: identity-server-prometheus-exporter-conf
-    namespace : {{ .Release.Namespace }}
+  name: identity-server-bin
+  namespace : {{ .Release.Namespace }}
 data:
-    config.yaml: |
-        startDelaySeconds: 0
-        jmxurl: service:jmx:rmi://localhost:11111/jndi/rmi://localhost:9999/jmxrmi
-        ssl: false
-        rules:
-            - pattern: ".*"
-
-{{ end }}
+  {{- $file := .Files }}
+  {{- range $path, $byte := .Files.Glob "confs/bin/*" }}
+  {{- $list := $path | splitList "/"}}
+  {{- $length := len $list }}
+  {{- $last := add $length -1 }}
+  {{ index $list $last }}: |-
+    {{- range $file.Lines $path }}
+      {{ . }}
+    {{- end }}
+  {{- end }}

--- a/advanced/helm/is-pattern-1/templates/is/identity-server-deployment.yaml
+++ b/advanced/helm/is-pattern-1/templates/is/identity-server-deployment.yaml
@@ -28,10 +28,14 @@ spec:
   selector:
     matchLabels:
       deployment: wso2is
+      app: wso2is
+      monitoring: {{ default "jmx" .Values.wso2.monitoring.prometheus.jmxJobName }}
   template:
     metadata:
       labels:
         deployment: wso2is
+        app: wso2is
+        monitoring: jmx
     spec:
       initContainers:
       {{ if .Values.wso2.mysql.enabled }}
@@ -54,6 +58,19 @@ spec:
       - name: init-elasticsearch
         image: busybox:1.31
         command: ['sh', '-c', 'echo -e "Checking for the availability of Elasticsearch Server deployment"; while ! nc -z {{ default "wso2-elasticsearch-master" .Values.wso2.centralizedLogging.logstash.elasticsearch.host }} 9200; do sleep 1; printf "-"; done; echo -e "  >> Elasticsearch server has started";']
+      {{ end }}
+      {{ if .Values.wso2.monitoring.enabled }}
+      - name: init-jmx-exporter
+        image: busybox:1.31
+        command:
+          - /bin/sh
+          - "-c"
+          - |
+            set -e
+            wget https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.12.0/jmx_prometheus_javaagent-0.12.0.jar -P /jmx-jar/
+        volumeMounts:
+          - name: shared-prometheus-jmx-jar
+            mountPath: /jmx-jar
       {{ end }}
       containers:
       - name: wso2is
@@ -83,6 +100,7 @@ spec:
           initialDelaySeconds: {{ default 250 .Values.wso2.deployment.wso2is.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ default 10 .Values.wso2.deployment.wso2is.readinessProbe.periodSeconds }}
         imagePullPolicy: {{ default "Always" .Values.wso2.deployment.wso2is.imagePullPolicy }}
+        command: ["/home/wso2carbon/entrypoint.sh"]
         resources:
           requests:
             memory: {{ .Values.wso2.deployment.wso2is.resources.requests.memory }}
@@ -101,6 +119,11 @@ spec:
           protocol: TCP
         - containerPort: 9443
           protocol: TCP
+        {{ if .Values.wso2.monitoring.enabled }}
+        - containerPort: 2222
+          protocol: TCP
+          name: metrics
+        {{ end }}
         volumeMounts:
         - name: identity-server-conf
           mountPath: /home/wso2carbon/wso2-config-volume/repository/conf
@@ -123,6 +146,15 @@ spec:
         - name: identity-server-conf-entrypoint
           mountPath: /home/wso2carbon/entrypoint.sh
           subPath: docker-entrypoint.sh
+        {{ if .Values.wso2.monitoring.enabled }}
+        - name: shared-prometheus-jmx-jar
+          mountPath: /home/wso2carbon/prometheus
+        - name: identity-server-prometheus-exporter-conf
+          mountPath: /home/wso2carbon/prometheus/config.yaml
+          subPath: config.yaml
+        - name: identity-server-bin
+          mountPath: /home/wso2carbon/wso2-config-volume/bin
+        {{ end }}
       {{ if .Values.wso2.centralizedLogging.enabled }}
         - name: shared-logs
           mountPath: /home/wso2carbon/wso2is-5.8.0/repository/logs/
@@ -213,4 +245,14 @@ spec:
       - name: logstash-elasticsearch-creds
         secret:
           secretName: logstash-elasticsearch-creds
+      {{ end }}
+      {{ if .Values.wso2.monitoring.enabled }}
+      - name: shared-prometheus-jmx-jar
+        emptyDir: {}
+      - name: identity-server-prometheus-exporter-conf
+        configMap:
+          name: identity-server-prometheus-exporter-conf
+      - name: identity-server-bin
+        configMap:
+          name: identity-server-bin
       {{ end }}

--- a/advanced/helm/is-pattern-1/templates/is/identity-server-prometheus-blackbox-serviceMonitor.yaml
+++ b/advanced/helm/is-pattern-1/templates/is/identity-server-prometheus-blackbox-serviceMonitor.yaml
@@ -1,0 +1,50 @@
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{ if .Values.wso2.monitoring.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+ name: identity-server-prometheus-blackbox-monitoring
+ labels:
+    {{- range $key, $value := .Values.wso2.monitoring.prometheus.serviceMonitor.labels  }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+    namespaceSelector:
+        matchNames:
+            - {{ .Release.Namespace }}
+    selector:
+        matchLabels:
+            app.kubernetes.io/name: prometheus-blackbox-exporter
+    endpoints:
+    - interval: 30s
+      metricRelabelings:
+          - sourceLabels:
+                - __address__
+            targetLabel: __param_target
+          - sourceLabels:
+                - __param_target
+            targetLabel: instance
+          - replacement: https://{{ template "fullname" . }}-service:9443/carbon/admin/login.jsp
+            targetLabel: target
+      params:
+          module:
+              - http_2xx
+          target:
+              - https://{{ template "fullname" . }}-service:9443/carbon/admin/login.jsp
+      path: /probe
+      port: http
+      scheme: http
+      scrapeTimeout: 30s
+{{ end }}

--- a/advanced/helm/is-pattern-1/templates/is/identity-server-prometheus-exporter-conf.yaml
+++ b/advanced/helm/is-pattern-1/templates/is/identity-server-prometheus-exporter-conf.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+{{ if .Values.wso2.monitoring.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: identity-server-prometheus-exporter-conf
+    namespace : {{ .Release.Namespace }}
+data:
+    config.yaml: |
+        startDelaySeconds: 0
+        jmxurl: service:jmx:rmi://localhost:11111/jndi/rmi://localhost:9999/jmxrmi
+        ssl: false
+        rules:
+            - pattern: ".*"
+
+{{ end }}

--- a/advanced/helm/is-pattern-1/templates/is/identity-server-prometheus-serviceMonitor.yaml
+++ b/advanced/helm/is-pattern-1/templates/is/identity-server-prometheus-serviceMonitor.yaml
@@ -1,0 +1,34 @@
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific
+{{ if .Values.wso2.monitoring.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+    name: identity-server-prometheus-monitoring
+    labels:
+        {{- range $key, $value := .Values.wso2.monitoring.prometheus.serviceMonitor.labels  }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+spec:
+    jobLabel: monitoring
+    selector:
+        matchLabels:
+            app: wso2is
+    Namespace Selector:
+        Match Names:
+            - {{ .Release.Namespace }}
+    endpoints:
+        - port: metrics
+          interval: 1s
+          Path:  /metrics
+{{ end }}

--- a/advanced/helm/is-pattern-1/templates/is/identity-server-prometheus-serviceMonitor.yaml
+++ b/advanced/helm/is-pattern-1/templates/is/identity-server-prometheus-serviceMonitor.yaml
@@ -15,6 +15,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
     name: identity-server-prometheus-monitoring
+    namespace: {{ .Release.Namespace }}
     labels:
         {{- range $key, $value := .Values.wso2.monitoring.prometheus.serviceMonitor.labels  }}
         {{ $key }}: {{ $value | quote }}

--- a/advanced/helm/is-pattern-1/templates/is/identity-server-service.yaml
+++ b/advanced/helm/is-pattern-1/templates/is/identity-server-service.yaml
@@ -17,9 +17,14 @@ kind: Service
 metadata:
   name: {{ template "fullname" . }}-service
   namespace : {{ .Release.Namespace }}
+  labels:
+    deployment: wso2is
+    app: wso2is
+    monitoring: jmx
 spec:
   selector:
     deployment: wso2is
+    app: wso2is
   ports:
   - name: servlet-http
     port: 9763
@@ -29,3 +34,9 @@ spec:
     port: 9443
     targetPort: 9443
     protocol: TCP
+  {{ if .Values.wso2.monitoring.enabled }}
+  - name: metrics
+    port: 2222
+    targetPort: 2222
+    protocol: TCP
+  {{ end }}

--- a/advanced/helm/is-pattern-1/values.yaml
+++ b/advanced/helm/is-pattern-1/values.yaml
@@ -86,12 +86,20 @@ wso2:
         host: wso2-elasticsearch-master
         username: "elastic"
         password: "changeme"
-      readinessProbe:
-        initialDelaySeconds: 20
-        periodSeconds: 30
-      livenessProbe:
-        initialDelaySeconds: 20
-        periodSeconds: 30
+      indexNodeID:
+        wso2ISNode: "wso2is-node"
+  # Configurations for Prometheus monitoring
+  monitoring:
+    # Enable Prometheus monitoring. This will start Prometheus exporter on port 2222 and deploy Service monitors
+    # for JVM, JMX and Blackbox exporter for Login calls
+    enabled: true
+    prometheus:
+      serviceMonitor:
+          # Prometheus Operator labels to identify Service monitors
+          labels:
+            release: monitoring
+      # Job name of the JMX events
+      jmxJobName: "jmx"
 
 kubernetes:
   # Name of Kubernetes service account

--- a/advanced/helm/is-pattern-1/values.yaml
+++ b/advanced/helm/is-pattern-1/values.yaml
@@ -86,14 +86,14 @@ wso2:
         host: wso2-elasticsearch-master
         username: "elastic"
         password: "changeme"
-      indexNodeID:
-        wso2ISNode: "wso2is-node"
   # Configurations for Prometheus monitoring
   monitoring:
     # Enable Prometheus monitoring. This will start Prometheus exporter on port 2222 and deploy Service monitors
     # for JVM, JMX and Blackbox exporter for Login calls
-    enabled: true
+    enabled: false
     prometheus:
+      # If the black box exporter is deployed in a different Name space
+      #blackBoxNamespace:
       serviceMonitor:
           # Prometheus Operator labels to identify Service monitors
           labels:

--- a/advanced/helm/is-pattern-2/README.md
+++ b/advanced/helm/is-pattern-2/README.md
@@ -67,7 +67,15 @@ If you do not have active WSO2 subscription do not change the parameters `wso2.s
 | `wso2.centralizedLogging.logstash.imageTag`                                 | Logstash Sidecar container image tag                                                      | 7.2.0                       |  
 | `wso2.centralizedLogging.logstash.elasticsearch.username`                   | Elasticsearch username                                                                    | elastic                     |  
 | `wso2.centralizedLogging.logstash.elasticsearch.password`                   | Elasticsearch password                                                                    | changeme                    |  
-| `wso2.centralizedLogging.logstash.indexNodeID.wso2ISNode`                   | Elasticsearch IS Node log index ID(index name: ${NODE_ID}-${NODE_IP})                     | wso2                        |
+
+###### Monitoring Configurations
+
+| Parameter                                                                   | Description                                                                               | Default Value               |
+|-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|-----------------------------|
+| `wso2.monitoring.enabled`                                                   | Enable Prometheus monitoring                                                              | false                       |                                                                                         |                             |    
+| `wso2.monitoring.prometheus.blackBoxNamespace`                              | Prometheus blackbox exporter namespace                                                    | <RELEASE_NAMESPACE>         |  
+| `wso2.monitoring.prometheus.jmxJobName`                                     | Prometheus job name                                                                       | jmx                         |  
+| `wso2.monitoring.prometheus.serviceMonitor.labels`                          | Prometheus labels for identifying Service Monitor                                         | "release: monitoring"       |  
 
 ###### Identity Server Configurations
 
@@ -95,36 +103,52 @@ If you do not have active WSO2 subscription do not change the parameters `wso2.s
 
 | Parameter                                                                   | Description                                                                               | Default Value               |
 |-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|-----------------------------|
-| `wso2.deployment.wso2isAnalyticsWorker.imageName`                           | Image name for IS node                                                                    | wso2is                     |
-| `wso2.deployment.wso2isAnalyticsWorker.imageTag`                            | Image tag for IS node                                                                     | 5.8.0                       |
-| `wso2.deployment.wso2isAnalyticsWorker.replicas`                            | Number of replicas for IS node                                                            | 2                           |
-| `wso2.deployment.wso2isAnalyticsWorker.minReadySeconds`                     | Refer to [doc](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#deploymentspec-v1-apps)| 1  30                        |
-| `wso2.deployment.wso2isAnalyticsWorker.strategy.rollingUpdate.maxSurge`     | Refer to [doc](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#deploymentstrategy-v1-apps) | 2                           |
-| `wso2.deployment.wso2isAnalyticsWorker.strategy.rollingUpdate.maxUnavailable`              | Refer to [doc](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#deploymentstrategy-v1-apps) | 0                           |
-| `wso2.deployment.wso2isAnalyticsWorker.livenessProbe.initialDelaySeconds`   | Initial delay for the live-ness probe for IS node                                         | 20                           |
-| `wso2.deployment.wso2isAnalyticsWorker.livenessProbe.periodSeconds`         | Period of the live-ness probe for IS node                                                 | 10                           |
-| `wso2.deployment.wso2isAnalyticsWorker.readinessProbe.initialDelaySeconds`  | Initial delay for the readiness probe for IS node                                         | 20                           |
-| `wso2.deployment.wso2isAnalyticsWorker.readinessProbe.periodSeconds`        | Period of the readiness probe for IS node                                                 | 10                           |
-| `wso2.deployment.wso2isAnalyticsWorker.imagePullPolicy`                     | Refer to [doc](https://kubernetes.io/docs/concepts/containers/images#updating-images)     | Always                       |
-| `wso2.deployment.wso2isAnalyticsWorker.resources.requests.memory`           | The minimum amount of memory that should be allocated for a Pod                           | 4Gi                          |
-| `wso2.deployment.wso2isAnalyticsWorker.resources.requests.cpu`              | The minimum amount of CPU that should be allocated for a Pod                              | 2000m                        |
-| `wso2.deployment.wso2isAnalyticsWorker.resources.limits.memory`             | The maximum amount of memory that should be allocated for a Pod                           | 4Gi                          |
-| `wso2.deployment.wso2isAnalyticsWorker.resources.limits.cpu`                | The maximum amount of CPU that should be allocated for a Pod                              | 2000m                        |
+| `wso2.deployment.wso2isAnalyticsWorker1.imageName`                           | Image name for IS Analytics Node 1                                                                   | wso2is                     |
+| `wso2.deployment.wso2isAnalyticsWorker1.imageTag`                            | Image tag for IS Analytics Node 1                                                                    | 5.8.0                       |
+| `wso2.deployment.wso2isAnalyticsWorker1.replicas`                            | Number of replicas for IS Analytics Node 1                                                           | 1                           |
+| `wso2.deployment.wso2isAnalyticsWorker1.minReadySeconds`                     | Refer to [doc](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#deploymentspec-v1-apps)| 1  30                        |
+| `wso2.deployment.wso2isAnalyticsWorker1.strategy.rollingUpdate.maxSurge`     | Refer to [doc](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#deploymentstrategy-v1-apps) | 2                           |
+| `wso2.deployment.wso2isAnalyticsWorker1.strategy.rollingUpdate.maxUnavailable`              | Refer to [doc](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#deploymentstrategy-v1-apps) | 0                           |
+| `wso2.deployment.wso2isAnalyticsWorker1.livenessProbe.initialDelaySeconds`   | Initial delay for the live-ness probe for IS Analytics Node 1                                        | 20                           |
+| `wso2.deployment.wso2isAnalyticsWorker1.livenessProbe.periodSeconds`         | Period of the live-ness probe for IS Analytics Node 1                                                | 10                           |
+| `wso2.deployment.wso2isAnalyticsWorker1.readinessProbe.initialDelaySeconds`  | Initial delay for the readiness probe for IS Analytics Node 1                                        | 20                           |
+| `wso2.deployment.wso2isAnalyticsWorker1.readinessProbe.periodSeconds`        | Period of the readiness probe for IS Analytics Node 1                                                | 10                           |
+| `wso2.deployment.wso2isAnalyticsWorker1.imagePullPolicy`                     | Refer to [doc](https://kubernetes.io/docs/concepts/containers/images#updating-images)     | Always                       |
+| `wso2.deployment.wso2isAnalyticsWorker1.resources.requests.memory`           | The minimum amount of memory that should be allocated for a Pod                           | 4Gi                          |
+| `wso2.deployment.wso2isAnalyticsWorker1.resources.requests.cpu`              | The minimum amount of CPU that should be allocated for a Pod                              | 2000m                        |
+| `wso2.deployment.wso2isAnalyticsWorker1.resources.limits.memory`             | The maximum amount of memory that should be allocated for a Pod                           | 4Gi                          |
+| `wso2.deployment.wso2isAnalyticsWorker1.resources.limits.cpu`                | The maximum amount of CPU that should be allocated for a Pod                              | 2000m                        |
+| `wso2.deployment.wso2isAnalyticsWorker2.imageName`                           | Image name for IS Analytics Node 1                                                                    | wso2is                     |
+| `wso2.deployment.wso2isAnalyticsWorker2.imageTag`                            | Image tag for IS Analytics Node 1                                                                     | 5.8.0                       |
+| `wso2.deployment.wso2isAnalyticsWorker2.replicas`                            | Number of replicas for IS Analytics Node 1                                                            | 2                           |
+| `wso2.deployment.wso2isAnalyticsWorker2.minReadySeconds`                     | Refer to [doc](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#deploymentspec-v1-apps)| 1  30                        |
+| `wso2.deployment.wso2isAnalyticsWorker2.strategy.rollingUpdate.maxSurge`     | Refer to [doc](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#deploymentstrategy-v1-apps) | 2                           |
+| `wso2.deployment.wso2isAnalyticsWorker2.strategy.rollingUpdate.maxUnavailable`              | Refer to [doc](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#deploymentstrategy-v1-apps) | 0                           |
+| `wso2.deployment.wso2isAnalyticsWorker2.livenessProbe.initialDelaySeconds`   | Initial delay for the live-ness probe for IS Analytics Node 1                                         | 20                           |
+| `wso2.deployment.wso2isAnalyticsWorker2.livenessProbe.periodSeconds`         | Period of the live-ness probe for IS Analytics Node 1                                                 | 10                           |
+| `wso2.deployment.wso2isAnalyticsWorker2.readinessProbe.initialDelaySeconds`  | Initial delay for the readiness probe for IS Analytics Node 1                                         | 20                           |
+| `wso2.deployment.wso2isAnalyticsWorker2.readinessProbe.periodSeconds`        | Period of the readiness probe for IS Analytics Node 1                                                 | 10                           |
+| `wso2.deployment.wso2isAnalyticsWorker2.imagePullPolicy`                     | Refer to [doc](https://kubernetes.io/docs/concepts/containers/images#updating-images)     | Always                       |
+| `wso2.deployment.wso2isAnalyticsWorker2.resources.requests.memory`           | The minimum amount of memory that should be allocated for a Pod                           | 4Gi                          |
+| `wso2.deployment.wso2isAnalyticsWorker2.resources.requests.cpu`              | The minimum amount of CPU that should be allocated for a Pod                              | 2000m                        |
+| `wso2.deployment.wso2isAnalyticsWorker2.resources.limits.memory`             | The maximum amount of memory that should be allocated for a Pod                           | 4Gi                          |
+| `wso2.deployment.wso2isAnalyticsWorker2.resources.limits.cpu`                | The maximum amount of CPU that should be allocated for a Pod                              | 2000m                        |
+
 
 ###### Analytics Dashboard Runtime Configurations
 
 | Parameter                                                                   | Description                                                                               | Default Value               |
 |-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|-----------------------------|
-| `wso2.deployment.wso2isAnalyticsDashboard.imageName`                        | Image name for IS node                                                                    | wso2is                      |
-| `wso2.deployment.wso2isAnalyticsDashboard.imageTag`                         | Image tag for IS node                                                                     | 5.8.0                       |
-| `wso2.deployment.wso2isAnalyticsDashboard.replicas`                         | Number of replicas for IS node                                                            | 2                           |
+| `wso2.deployment.wso2isAnalyticsDashboard.imageName`                        | Image name for IS Analytics Node 2                                                                    | wso2is                      |
+| `wso2.deployment.wso2isAnalyticsDashboard.imageTag`                         | Image tag for IS Analytics Node 2                                                                     | 5.8.0                       |
+| `wso2.deployment.wso2isAnalyticsDashboard.replicas`                         | Number of replicas for IS Analytics Node 2                                                            | 1                           |
 | `wso2.deployment.wso2isAnalyticsDashboard.minReadySeconds`                  | Refer to [doc](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#deploymentspec-v1-apps)| 1  30                        |
 | `wso2.deployment.wso2isAnalyticsDashboard.strategy.rollingUpdate.maxSurge`  | Refer to [doc](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#deploymentstrategy-v1-apps) | 2                           |
 | `wso2.deployment.wso2isAnalyticsDashboard.strategy.rollingUpdate.maxUnavailable`              | Refer to [doc](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#deploymentstrategy-v1-apps) | 0                           |
-| `wso2.deployment.wso2isAnalyticsDashboard.livenessProbe.initialDelaySeconds`| Initial delay for the live-ness probe for IS node                                         | 20                           |
-| `wso2.deployment.wso2isAnalyticsDashboard.livenessProbe.periodSeconds`      | Period of the live-ness probe for IS node                                                 | 10                           |
-| `wso2.deployment.wso2isAnalyticsDashboard.readinessProbe.initialDelaySeconds`| Initial delay for the readiness probe for IS node                                        | 20                           |
-| `wso2.deployment.wso2isAnalyticsDashboard.readinessProbe.periodSeconds`     | Period of the readiness probe for IS node                                                 | 10                           |
+| `wso2.deployment.wso2isAnalyticsDashboard.livenessProbe.initialDelaySeconds`| Initial delay for the live-ness probe for IS Analytics Node 2                                         | 20                           |
+| `wso2.deployment.wso2isAnalyticsDashboard.livenessProbe.periodSeconds`      | Period of the live-ness probe for IS Analytics Node 2                                                 | 10                           |
+| `wso2.deployment.wso2isAnalyticsDashboard.readinessProbe.initialDelaySeconds`| Initial delay for the readiness probe for IS Analytics Node 2                                        | 20                           |
+| `wso2.deployment.wso2isAnalyticsDashboard.readinessProbe.periodSeconds`     | Period of the readiness probe for IS Analytics Node 2                                                 | 10                           |
 | `wso2.deployment.wso2isAnalyticsDashboard.imagePullPolicy`                  | Refer to [doc](https://kubernetes.io/docs/concepts/containers/images#updating-images)     | Always                       |
 | `wso2.deployment.wso2isAnalyticsDashboard.resources.requests.memory`        | The minimum amount of memory that should be allocated for a Pod                           | 4Gi                          |
 | `wso2.deployment.wso2isAnalyticsDashboard.resources.requests.cpu`           | The minimum amount of CPU that should be allocated for a Pod                              | 2000m                        |

--- a/advanced/helm/is-pattern-2/confs/is-analytics-dashboard/wso2/dashboard/bin/carbon.sh
+++ b/advanced/helm/is-pattern-2/confs/is-analytics-dashboard/wso2/dashboard/bin/carbon.sh
@@ -1,0 +1,296 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ----------------------------------------------------------------------------
+# Main Script for the WSO2 Carbon Server
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of WSO2 Carbon installation. If not set I will  try
+#                   to figure it out.
+#   RUNTIME_HOME  Home of WSO2 Carbon Runtime. .
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+#   JAVA_OPTS       (Optional) Java runtime options used when the commands
+#                   is executed.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+# -----------------------------------------------------------------------------
+
+# OS specific support.  $var _must_ be set to either true or false.
+#ulimit -n 100000
+
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+TEMPCURDIR=`dirname "$PRG"`
+
+# Only set RUNTIME_HOME if not already set
+[ -z "$RUNTIME_HOME" ] && RUNTIME_HOME=`cd "$TEMPCURDIR/.." ; pwd`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$TEMPCURDIR/../../../" ; pwd`
+
+# Only set RUNTIME if not already set
+[ -z "$RUNTIME" ] && RUNTIME=${RUNTIME_HOME##*/}
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$RUNTIME_HOME" ] && RUNTIME_HOME=`cygpath --unix "$RUNTIME_HOME"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=java
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly."
+  echo " CARBON cannot execute $JAVACMD"
+  exit 1
+fi
+
+# if JAVA_HOME is not set we're not happy
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+if [ -e "$RUNTIME_HOME/runtime.pid" ]; then
+  PID=`cat "$RUNTIME_HOME"/runtime.pid`
+fi
+
+# ----- Process the input command ----------------------------------------------
+args=""
+for c in $*
+do
+    if [ "$c" = "--debug" ] || [ "$c" = "-debug" ] || [ "$c" = "debug" ]; then
+          CMD="--debug"
+          continue
+    elif [ "$CMD" = "--debug" ]; then
+          if [ -z "$PORT" ]; then
+                PORT=$c
+          fi
+    elif [ "$c" = "--stop" ] || [ "$c" = "-stop" ] || [ "$c" = "stop" ]; then
+          CMD="stop"
+    elif [ "$c" = "--start" ] || [ "$c" = "-start" ] || [ "$c" = "start" ]; then
+          CMD="start"
+    elif [ "$c" = "--version" ] || [ "$c" = "-version" ] || [ "$c" = "version" ]; then
+          CMD="version"
+    elif [ "$c" = "--restart" ] || [ "$c" = "-restart" ] || [ "$c" = "restart" ]; then
+          CMD="restart"
+    elif [ "$c" = "--test" ] || [ "$c" = "-test" ] || [ "$c" = "test" ]; then
+          CMD="test"
+    else
+        args="$args $c"
+    fi
+done
+
+if [ "$CMD" = "--debug" ]; then
+  if [ "$PORT" = "" ]; then
+    echo " Please specify the debug port after the --debug option"
+    exit 1
+  fi
+  if [ -n "$JAVA_OPTS" ]; then
+    echo "Warning !!!. User specified JAVA_OPTS will be ignored, once you give the --debug option."
+  fi
+  CMD="RUN"
+  JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=$PORT"
+  echo "Please start the remote debugging client to continue..."
+elif [ "$CMD" = "start" ]; then
+  if [ -e "$RUNTIME_HOME/runtime.pid" ]; then
+    if  ps -p $PID > /dev/null ; then
+      echo "Process is already running"
+      exit 0
+    fi
+  fi
+  export CARBON_HOME=$CARBON_HOME
+# using nohup bash to avoid erros in solaris OS.TODO
+  nohup bash $RUNTIME_HOME/bin/carbon.sh $args > /dev/null 2>&1 &
+  exit 0
+elif [ "$CMD" = "stop" ]; then
+  export CARBON_HOME=$CARBON_HOME
+  kill -term `cat $RUNTIME_HOME/runtime.pid`
+  exit 0
+elif [ "$CMD" = "restart" ]; then
+  export CARBON_HOME=$CARBON_HOME
+  kill -term `cat $RUNTIME_HOME/runtime.pid`
+  process_status=0
+  pid=`cat $RUNTIME_HOME/runtime.pid`
+  while [ "$process_status" -eq "0" ]
+  do
+        sleep 1;
+        ps -p$pid 2>&1 > /dev/null
+        process_status=$?
+  done
+
+# using nohup bash to avoid erros in solaris OS.TODO
+  nohup bash $RUNTIME_HOME/bin/carbon.sh $args > /dev/null 2>&1 &
+  exit 0
+elif [ "$CMD" = "test" ]; then
+    JAVACMD="exec "$JAVACMD""
+elif [ "$CMD" = "version" ]; then
+  cat $CARBON_HOME/bin/kernel-version.txt
+  exit 0
+fi
+
+# ---------- Handle the SSL Issue with proper JDK version --------------------
+jdk_18=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[8]"`
+if [ "$jdk_18" = "" ]; then
+   echo " Starting WSO2 Carbon (in unsupported JDK)"
+   echo " [ERROR] CARBON is supported only on JDK 1.8"
+fi
+
+CARBON_XBOOTCLASSPATH=""
+for f in "$CARBON_HOME"/bin/bootstrap/xboot/*.jar
+do
+    if [ "$f" != "$CARBON_HOME/bin/bootstrap/xboot/*.jar" ];then
+        CARBON_XBOOTCLASSPATH="$CARBON_XBOOTCLASSPATH":$f
+    fi
+done
+
+JAVA_ENDORSED_DIRS="$CARBON_HOME/bin/bootstrap/endorsed":"$JAVA_HOME/jre/lib/endorsed":"$JAVA_HOME/lib/endorsed"
+
+CARBON_CLASSPATH=""
+if [ -e "$JAVA_HOME/bin/bootstrap/tools.jar" ]; then
+    CARBON_CLASSPATH="$JAVA_HOME/lib/tools.jar"
+fi
+for f in "$CARBON_HOME"/bin/bootstrap/*.jar
+do
+    if [ "$f" != "$CARBON_HOME/bin/bootstrap/*.jar" ];then
+        CARBON_CLASSPATH="$CARBON_CLASSPATH":$f
+    fi
+done
+for t in "$CARBON_HOME"/bin/bootstrap/commons-lang*.jar
+do
+    CARBON_CLASSPATH="$CARBON_CLASSPATH":$t
+done
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  RUNTIME_HOME=`cygpath --absolute --windows "$RUNTIME_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+  CARBON_CLASSPATH=`cygpath --path --windows "$CARBON_CLASSPATH"`
+  CARBON_XBOOTCLASSPATH=`cygpath --path --windows "$CARBON_XBOOTCLASSPATH"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+echo JAVA_HOME environment variable is set to $JAVA_HOME
+echo CARBON_HOME environment variable is set to $CARBON_HOME
+echo RUNTIME_HOME environment variable is set to $RUNTIME_HOME
+
+cd "$RUNTIME_HOME"
+
+START_EXIT_STATUS=121
+status=$START_EXIT_STATUS
+
+#To monitor a Carbon server in remote JMX mode on linux host machines, set the below system property.
+#   -Djava.rmi.server.hostname="your.IP.goes.here"
+
+while [ "$status" = "$START_EXIT_STATUS" ]
+do
+    $JAVACMD \
+    -Xbootclasspath/a:"$CARBON_XBOOTCLASSPATH" \
+    -Xms256m -Xmx1024m \
+    -XX:+HeapDumpOnOutOfMemoryError \
+    -XX:HeapDumpPath="$RUNTIME_HOME/logs/heap-dump.hprof" \
+    $JAVA_OPTS \
+    -classpath "$CARBON_CLASSPATH" \
+    -Djava.endorsed.dirs="$JAVA_ENDORSED_DIRS" \
+    -Djava.io.tmpdir="$CARBON_HOME/tmp" \
+    -Dcarbon.registry.root=/ \
+    -Djava.command="$JAVACMD" \
+    -Dcarbon.home="$CARBON_HOME" \
+    -Dwso2.runtime.path="$RUNTIME_HOME" \
+    -Dwso2.runtime="$RUNTIME" \
+    -Djava.util.logging.config.file="$RUNTIME_HOME/bin/bootstrap/logging.properties" \
+    -Djava.security.egd=file:/dev/./urandom \
+    -Dfile.encoding=UTF8 \
+    -Djavax.net.ssl.keyStore="$CARBON_HOME/resources/security/wso2carbon.jks" \
+    -Djavax.net.ssl.keyStorePassword="wso2carbon" \
+    -Djavax.net.ssl.trustStore="$CARBON_HOME/resources/security/client-truststore.jks" \
+    -Djavax.net.ssl.trustStorePassword="wso2carbon" \
+    -javaagent:/home/wso2carbon/prometheus/jmx_prometheus_javaagent-0.12.0.jar=2222:/home/wso2carbon/prometheus/config.yaml \
+    org.wso2.carbon.launcher.Main $*
+    status=$?
+done

--- a/advanced/helm/is-pattern-2/confs/is-analytics-worker/conf/worker/deployment.yaml
+++ b/advanced/helm/is-pattern-2/confs/is-analytics-worker/conf/worker/deployment.yaml
@@ -194,7 +194,7 @@ data.agent.config:
 # This is the main configuration for metrics
 wso2.metrics:
   # Enable Metrics
-  enabled: true
+  enabled: false
   reporting:
     console:
         # The name for the Console Reporter

--- a/advanced/helm/is-pattern-2/confs/is-analytics-worker/wso2/worker/bin/carbon.sh
+++ b/advanced/helm/is-pattern-2/confs/is-analytics-worker/wso2/worker/bin/carbon.sh
@@ -1,0 +1,296 @@
+#!/bin/sh
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ----------------------------------------------------------------------------
+# Main Script for the WSO2 Carbon Server
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of WSO2 Carbon installation. If not set I will  try
+#                   to figure it out.
+#   RUNTIME_HOME  Home of WSO2 Carbon Runtime. .
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+#   JAVA_OPTS       (Optional) Java runtime options used when the commands
+#                   is executed.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+# -----------------------------------------------------------------------------
+
+# OS specific support.  $var _must_ be set to either true or false.
+#ulimit -n 100000
+
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+TEMPCURDIR=`dirname "$PRG"`
+
+# Only set RUNTIME_HOME if not already set
+[ -z "$RUNTIME_HOME" ] && RUNTIME_HOME=`cd "$TEMPCURDIR/.." ; pwd`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$TEMPCURDIR/../../../" ; pwd`
+
+# Only set RUNTIME if not already set
+[ -z "$RUNTIME" ] && RUNTIME=${RUNTIME_HOME##*/}
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$RUNTIME_HOME" ] && RUNTIME_HOME=`cygpath --unix "$RUNTIME_HOME"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=java
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly."
+  echo " CARBON cannot execute $JAVACMD"
+  exit 1
+fi
+
+# if JAVA_HOME is not set we're not happy
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+if [ -e "$RUNTIME_HOME/runtime.pid" ]; then
+  PID=`cat "$RUNTIME_HOME"/runtime.pid`
+fi
+
+# ----- Process the input command ----------------------------------------------
+args=""
+for c in $*
+do
+    if [ "$c" = "--debug" ] || [ "$c" = "-debug" ] || [ "$c" = "debug" ]; then
+          CMD="--debug"
+          continue
+    elif [ "$CMD" = "--debug" ]; then
+          if [ -z "$PORT" ]; then
+                PORT=$c
+          fi
+    elif [ "$c" = "--stop" ] || [ "$c" = "-stop" ] || [ "$c" = "stop" ]; then
+          CMD="stop"
+    elif [ "$c" = "--start" ] || [ "$c" = "-start" ] || [ "$c" = "start" ]; then
+          CMD="start"
+    elif [ "$c" = "--version" ] || [ "$c" = "-version" ] || [ "$c" = "version" ]; then
+          CMD="version"
+    elif [ "$c" = "--restart" ] || [ "$c" = "-restart" ] || [ "$c" = "restart" ]; then
+          CMD="restart"
+    elif [ "$c" = "--test" ] || [ "$c" = "-test" ] || [ "$c" = "test" ]; then
+          CMD="test"
+    else
+        args="$args $c"
+    fi
+done
+
+if [ "$CMD" = "--debug" ]; then
+  if [ "$PORT" = "" ]; then
+    echo " Please specify the debug port after the --debug option"
+    exit 1
+  fi
+  if [ -n "$JAVA_OPTS" ]; then
+    echo "Warning !!!. User specified JAVA_OPTS will be ignored, once you give the --debug option."
+  fi
+  CMD="RUN"
+  JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=$PORT"
+  echo "Please start the remote debugging client to continue..."
+elif [ "$CMD" = "start" ]; then
+  if [ -e "$RUNTIME_HOME/runtime.pid" ]; then
+    if  ps -p $PID > /dev/null ; then
+      echo "Process is already running"
+      exit 0
+    fi
+  fi
+  export CARBON_HOME=$CARBON_HOME
+# using nohup bash to avoid erros in solaris OS.TODO
+  nohup bash $RUNTIME_HOME/bin/carbon.sh $args > /dev/null 2>&1 &
+  exit 0
+elif [ "$CMD" = "stop" ]; then
+  export CARBON_HOME=$CARBON_HOME
+  kill -term `cat $RUNTIME_HOME/runtime.pid`
+  exit 0
+elif [ "$CMD" = "restart" ]; then
+  export CARBON_HOME=$CARBON_HOME
+  kill -term `cat $RUNTIME_HOME/runtime.pid`
+  process_status=0
+  pid=`cat $RUNTIME_HOME/runtime.pid`
+  while [ "$process_status" -eq "0" ]
+  do
+        sleep 1;
+        ps -p$pid 2>&1 > /dev/null
+        process_status=$?
+  done
+
+# using nohup bash to avoid erros in solaris OS.TODO
+  nohup bash $RUNTIME_HOME/bin/carbon.sh $args > /dev/null 2>&1 &
+  exit 0
+elif [ "$CMD" = "test" ]; then
+    JAVACMD="exec "$JAVACMD""
+elif [ "$CMD" = "version" ]; then
+  cat $CARBON_HOME/bin/kernel-version.txt
+  exit 0
+fi
+
+# ---------- Handle the SSL Issue with proper JDK version --------------------
+jdk_18=`$JAVA_HOME/bin/java -version 2>&1 | grep "1.[8]"`
+if [ "$jdk_18" = "" ]; then
+   echo " Starting WSO2 Carbon (in unsupported JDK)"
+   echo " [ERROR] CARBON is supported only on JDK 1.8"
+fi
+
+CARBON_XBOOTCLASSPATH=""
+for f in "$CARBON_HOME"/bin/bootstrap/xboot/*.jar
+do
+    if [ "$f" != "$CARBON_HOME/bin/bootstrap/xboot/*.jar" ];then
+        CARBON_XBOOTCLASSPATH="$CARBON_XBOOTCLASSPATH":$f
+    fi
+done
+
+JAVA_ENDORSED_DIRS="$CARBON_HOME/bin/bootstrap/endorsed":"$JAVA_HOME/jre/lib/endorsed":"$JAVA_HOME/lib/endorsed"
+
+CARBON_CLASSPATH=""
+if [ -e "$JAVA_HOME/bin/bootstrap/tools.jar" ]; then
+    CARBON_CLASSPATH="$JAVA_HOME/lib/tools.jar"
+fi
+for f in "$CARBON_HOME"/bin/bootstrap/*.jar
+do
+    if [ "$f" != "$CARBON_HOME/bin/bootstrap/*.jar" ];then
+        CARBON_CLASSPATH="$CARBON_CLASSPATH":$f
+    fi
+done
+for t in "$CARBON_HOME"/bin/bootstrap/commons-lang*.jar
+do
+    CARBON_CLASSPATH="$CARBON_CLASSPATH":$t
+done
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  RUNTIME_HOME=`cygpath --absolute --windows "$RUNTIME_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+  CARBON_CLASSPATH=`cygpath --path --windows "$CARBON_CLASSPATH"`
+  CARBON_XBOOTCLASSPATH=`cygpath --path --windows "$CARBON_XBOOTCLASSPATH"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+echo JAVA_HOME environment variable is set to $JAVA_HOME
+echo CARBON_HOME environment variable is set to $CARBON_HOME
+echo RUNTIME_HOME environment variable is set to $RUNTIME_HOME
+
+cd "$RUNTIME_HOME"
+
+START_EXIT_STATUS=121
+status=$START_EXIT_STATUS
+
+#To monitor a Carbon server in remote JMX mode on linux host machines, set the below system property.
+#   -Djava.rmi.server.hostname="your.IP.goes.here"
+
+while [ "$status" = "$START_EXIT_STATUS" ]
+do
+    $JAVACMD \
+    -Xbootclasspath/a:"$CARBON_XBOOTCLASSPATH" \
+    -Xms256m -Xmx1024m \
+    -XX:+HeapDumpOnOutOfMemoryError \
+    -XX:HeapDumpPath="$RUNTIME_HOME/logs/heap-dump.hprof" \
+    $JAVA_OPTS \
+    -classpath "$CARBON_CLASSPATH" \
+    -Djava.endorsed.dirs="$JAVA_ENDORSED_DIRS" \
+    -Djava.io.tmpdir="$CARBON_HOME/tmp" \
+    -Dcarbon.registry.root=/ \
+    -Djava.command="$JAVACMD" \
+    -Dcarbon.home="$CARBON_HOME" \
+    -Dwso2.runtime.path="$RUNTIME_HOME" \
+    -Dwso2.runtime="$RUNTIME" \
+    -Djava.util.logging.config.file="$RUNTIME_HOME/bin/bootstrap/logging.properties" \
+    -Djava.security.egd=file:/dev/./urandom \
+    -Dfile.encoding=UTF8 \
+    -Djavax.net.ssl.keyStore="$CARBON_HOME/resources/security/wso2carbon.jks" \
+    -Djavax.net.ssl.keyStorePassword="wso2carbon" \
+    -Djavax.net.ssl.trustStore="$CARBON_HOME/resources/security/client-truststore.jks" \
+    -Djavax.net.ssl.trustStorePassword="wso2carbon" \
+    -javaagent:/home/wso2carbon/prometheus/jmx_prometheus_javaagent-0.12.0.jar=2222:/home/wso2carbon/prometheus/config.yaml \
+    org.wso2.carbon.launcher.Main $*
+    status=$?
+done

--- a/advanced/helm/is-pattern-2/confs/is/bin/wso2server.sh
+++ b/advanced/helm/is-pattern-2/confs/is/bin/wso2server.sh
@@ -314,9 +314,8 @@ do
     -Dcom.ibm.cacheLocalHost=true \
     -DworkerNode=false \
     -DenableCorrelationLogs=false \
-    -Dorg.opensaml.httpclient.https.disableHostnameVerification=true \
-    -Dhttpclient.hostnameVerifier="AllowAll" \
- -Dorg.apache.xml.security.ignoreLineBreaks=false \
+    -javaagent:/home/wso2carbon/prometheus/jmx_prometheus_javaagent-0.12.0.jar=2222:/home/wso2carbon/prometheus/config.yaml \
+    -Dorg.apache.xml.security.ignoreLineBreaks=false \
     org.wso2.carbon.bootstrap.Bootstrap $*
     status=$?
 done

--- a/advanced/helm/is-pattern-2/confs/is/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-AuthenticationData.xml
+++ b/advanced/helm/is-pattern-2/confs/is/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-AuthenticationData.xml
@@ -7,7 +7,7 @@
     <property name="protocol">thrift</property>
     <property name="publishingMode">non-blocking</property>
     <property name="publishTimeout">0</property>
-    <property name="receiverURL">tcp://{{ ANALYTICS_WORKER_SERVICE }}:7612</property>
+    <property name="receiverURL">tcp://{{ ANALYTICS_WORKER_SERVICE-1 }}:7612|tcp://{{ ANALYTICS_WORKER_SERVICE-2 }}:7612</property>
     <property encrypted="false" name="password">admin</property>
   </to>
 </eventPublisher>

--- a/advanced/helm/is-pattern-2/confs/is/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-RoleData.xml
+++ b/advanced/helm/is-pattern-2/confs/is/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-RoleData.xml
@@ -24,7 +24,7 @@
     <property name="protocol">thrift</property>
     <property name="publishingMode">non-blocking</property>
     <property name="publishTimeout">0</property>
-    <property name="receiverURL">tcp://{{ ANALYTICS_WORKER_SERVICE }}:7612</property>
+    <property name="receiverURL">tcp://{{ ANALYTICS_WORKER_SERVICE-1 }}:7612|tcp://{{ ANALYTICS_WORKER_SERVICE-2 }}:7612</property>
     <property encrypted="false" name="password">admin</property>
   </to>
 </eventPublisher>

--- a/advanced/helm/is-pattern-2/confs/is/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-SessionData.xml
+++ b/advanced/helm/is-pattern-2/confs/is/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-SessionData.xml
@@ -7,7 +7,7 @@
     <property name="protocol">thrift</property>
     <property name="publishingMode">non-blocking</property>
     <property name="publishTimeout">0</property>
-    <property name="receiverURL">tcp://{{ ANALYTICS_WORKER_SERVICE }}:7612</property>
+    <property name="receiverURL">tcp://{{ ANALYTICS_WORKER_SERVICE-1 }}:7612|tcp://{{ ANALYTICS_WORKER_SERVICE-2 }}:7612</property>
     <property encrypted="false" name="password">admin</property>
   </to>
 </eventPublisher>

--- a/advanced/helm/is-pattern-2/confs/is/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-UserData.xml
+++ b/advanced/helm/is-pattern-2/confs/is/deployment/server/eventpublishers/IsAnalytics-Publisher-wso2event-UserData.xml
@@ -24,7 +24,7 @@
     <property name="protocol">thrift</property>
     <property name="publishingMode">non-blocking</property>
     <property name="publishTimeout">0</property>
-    <property name="receiverURL">tcp://{{ ANALYTICS_WORKER_SERVICE }}:7612</property>
+    <property name="receiverURL">tcp://{{ ANALYTICS_WORKER_SERVICE-1 }}:7612|tcp://{{ ANALYTICS_WORKER_SERVICE-2 }}:7612</property>
     <property encrypted="false" name="password">admin</property>
   </to>
 </eventPublisher>

--- a/advanced/helm/is-pattern-2/templates/analytics-dashboard/identity-server-analytics-dashboard-prometheus-blackbox-monitoring.yaml
+++ b/advanced/helm/is-pattern-2/templates/analytics-dashboard/identity-server-analytics-dashboard-prometheus-blackbox-monitoring.yaml
@@ -15,7 +15,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
- name: identity-server-prometheus-blackbox-monitoring
+ name: identity-server-analytics-dashboard-prometheus-blackbox-monitoring
  namespace: {{ if .Values.wso2.monitoring.prometheus.serviceMonitor.blackBoxNamespace }}{{ .Values.wso2.monitoring.prometheus.serviceMonitor.blackBoxNamespace  }}{{ else }}{{ .Release.Namespace }}{{ end }}
  labels:
     {{- range $key, $value := .Values.wso2.monitoring.prometheus.serviceMonitor.labels  }}
@@ -25,9 +25,9 @@ spec:
     namespaceSelector:
         matchNames:
             {{- if .Values.wso2.monitoring.prometheus.serviceMonitor.blackBoxNamespace }}
-            - {{ .Values.wso2.monitoring.prometheus.serviceMonitor.blackBoxNamespace  }}
+             - {{ .Values.wso2.monitoring.prometheus.serviceMonitor.blackBoxNamespace  }}
             {{- else }}
-            - {{ .Release.Namespace }}
+             - {{ .Release.Namespace }}
             {{- end }}
     selector:
         matchLabels:
@@ -41,13 +41,13 @@ spec:
           - sourceLabels:
                 - __param_target
             targetLabel: instance
-          - replacement: https://{{ template "fullname" . }}-service:9443/carbon/admin/login.jsp
+          - replacement: https://{{ template "fullname" . }}-analytics-dashboard-service.{{ .Release.Namespace }}.svc.cluster.local:9643/monitoring/login
             targetLabel: target
       params:
           module:
               - http_2xx
           target:
-              - https://{{ template "fullname" . }}-service:9443/carbon/admin/login.jsp
+              - https://{{ template "fullname" . }}-analytics-dashboard-service.{{ .Release.Namespace }}.svc.cluster.local:9643/monitoring/login
       path: /probe
       port: http
       scheme: http

--- a/advanced/helm/is-pattern-2/templates/analytics-dashboard/identity-server-analytics-dashboard-service.yaml
+++ b/advanced/helm/is-pattern-2/templates/analytics-dashboard/identity-server-analytics-dashboard-service.yaml
@@ -19,6 +19,8 @@ metadata:
   namespace : {{ .Release.Namespace }}
   labels:
     deployment: {{ template "fullname" . }}-analytics-dashboard
+    app: is-pattern-2
+    monitoring: {{ default "jmx" .Values.wso2.monitoring.prometheus.jmxJobName }}
 spec:
   ports:
     # ports that this service should serve on
@@ -26,7 +28,12 @@ spec:
       name: 'https'
       port: 9643
       protocol: TCP
-
+    {{ if .Values.wso2.monitoring.enabled }}
+    - name: metrics
+      port: 2222
+      targetPort: 2222
+      protocol: TCP
+    {{ end }}
   # label keys and values that must match in order to receive traffic for this service
   selector:
     deployment: {{ template "fullname" . }}-analytics-dashboard

--- a/advanced/helm/is-pattern-2/templates/analytics-dashboard/is-analytics-dashboard-carbon-conf.yaml
+++ b/advanced/helm/is-pattern-2/templates/analytics-dashboard/is-analytics-dashboard-carbon-conf.yaml
@@ -11,33 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
-kind: Service
+kind: ConfigMap
 metadata:
-  name: {{ template "fullname" . }}-analytics-worker-service
+  name: is-analytics-dashboard-carbon-conf
   namespace : {{ .Release.Namespace }}
-spec:
-  selector:
-    deployment: {{ template "fullname" . }}-analytics-worker
-  ports:
-  - name: servlet-https
-    port: 9091
-    targetPort: 9091
-    protocol: TCP
-  - name: siddhi-1
-    port: 7070
-    targetPort: 8082
-    protocol: TCP
-  - name: siddhi-2
-    port: 7443
-    targetPort: 11501
-    protocol: TCP
-  - name: data-reciver-1
-    port: 7612
-    targetPort: 7612
-    protocol: TCP
-  - name: data-receiver-2
-    port: 7712
-    targetPort: 7712
-    protocol: TCP
+data:
+  {{- $file := .Files }}
+  {{- range $path, $byte := .Files.Glob "confs/is-analytics-dashboard/wso2/dashboard/bin/*" }}
+  {{- $list := $path | splitList "/"}}
+  {{- $length := len $list }}
+  {{- $last := add $length -1 }}
+  {{ index $list $last }}: |-
+    {{- range $file.Lines $path }}
+    {{ . }}
+    {{- end }}
+  {{- end }}

--- a/advanced/helm/is-pattern-2/templates/analytics-worker/identity-server-analytics-worker-1-deployment.yaml
+++ b/advanced/helm/is-pattern-2/templates/analytics-worker/identity-server-analytics-worker-1-deployment.yaml
@@ -15,22 +15,27 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}-analytics-worker-deployment
+  name: {{ template "fullname" . }}-analytics-worker-1-deployment
   namespace : {{ .Release.Namespace }}
 spec:
-  replicas: {{ default 1 .Values.wso2.deployment.wso2isAnalyticsWorker.replicas }}
+  replicas: {{ default 1 .Values.wso2.deployment.wso2isAnalyticsWorker1.replicas }}
   strategy:
     rollingUpdate:
-      maxSurge: {{ default 1 .Values.wso2.deployment.wso2isAnalyticsWorker.strategy.rollingUpdate.maxSurge }}
-      maxUnavailable: {{ default 0 .Values.wso2.deployment.wso2isAnalyticsWorker.strategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ default 1 .Values.wso2.deployment.wso2isAnalyticsWorker1.strategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ default 0 .Values.wso2.deployment.wso2isAnalyticsWorker1.strategy.rollingUpdate.maxUnavailable }}
     type: RollingUpdate
   selector:
     matchLabels:
       deployment: {{ template "fullname" . }}-analytics-worker
+      app: is-pattern-2
+      monitoring: {{ default "jmx" .Values.wso2.monitoring.prometheus.jmxJobName }}
   template:
     metadata:
       labels:
         deployment: {{ template "fullname" . }}-analytics-worker
+        app: is-pattern-2
+        monitoring: {{ default "jmx" .Values.wso2.monitoring.prometheus.jmxJobName }}
+        node: node-1
     spec:
       initContainers:
       {{ if .Values.wso2.mysql.enabled }}
@@ -54,16 +59,29 @@ spec:
         image: busybox:1.31
         command: ['sh', '-c', 'echo -e "Checking for the availability of Elasticsearch Server deployment"; while ! nc -z {{ default "wso2-elasticsearch-master" .Values.wso2.centralizedLogging.logstash.elasticsearch.host }} 9200; do sleep 1; printf "-"; done; echo -e "  >> Elasticsearch server has started";']
       {{ end }}
+      {{ if .Values.wso2.monitoring.enabled }}
+      - name: init-jmx-exporter
+        image: busybox:1.31
+        command:
+          - /bin/sh
+          - "-c"
+          - |
+            set -e
+            wget https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.12.0/jmx_prometheus_javaagent-0.12.0.jar -P /jmx-jar/
+        volumeMounts:
+          - name: shared-prometheus-jmx-jar
+            mountPath: /jmx-jar
+      {{ end }}
       containers:
       - name: {{ template "fullname" . }}-analytics-worker
-        {{- if .Values.wso2.deployment.wso2isAnalyticsWorker.dockerRegistry }}
-        image: {{ .Values.wso2.deployment.wso2isAnalyticsWorker.dockerRegistry }}/{{ default "wso2is-analytics-worker" .Values.wso2.deployment.wso2isAnalyticsWorker.imageName }}
-        {{- $tag := .Values.wso2.deployment.wso2isAnalyticsWorker.imageTag }}
+        {{- if .Values.wso2.deployment.wso2isAnalyticsWorker1.dockerRegistry }}
+        image: {{ .Values.wso2.deployment.wso2isAnalyticsWorker1.dockerRegistry }}/{{ default "wso2is-analytics-worker" .Values.wso2.deployment.wso2isAnalyticsWorker1.imageName }}
+        {{- $tag := .Values.wso2.deployment.wso2isAnalyticsWorker1.imageTag }}
         {{- if not (eq $tag "") }}{{- printf ":%s" $tag -}}{{- end }}
         {{- else if or (eq .Values.wso2.subscription.username "") (eq .Values.wso2.subscription.password "") }}
-        image: wso2/{{ default "wso2is-analytics-worker" .Values.wso2.deployment.wso2isAnalyticsWorker.imageName }}:{{ default "5.8.0" .Values.wso2.deployment.wso2isAnalyticsWorker.imageTag }}
+        image: wso2/{{ default "wso2is-analytics-worker" .Values.wso2.deployment.wso2isAnalyticsWorker1.imageName }}:{{ default "5.8.0" .Values.wso2.deployment.wso2isAnalyticsWorker1.imageTag }}
         {{- else }}
-        image: docker.wso2.com/{{ default "wso2is-analytics-worker" .Values.wso2.deployment.wso2isAnalyticsWorker.imageName }}:{{ default "5.8.0" .Values.wso2.deployment.wso2isAnalyticsWorker.imageTag }}
+        image: docker.wso2.com/{{ default "wso2is-analytics-worker" .Values.wso2.deployment.wso2isAnalyticsWorker1.imageName }}:{{ default "5.8.0" .Values.wso2.deployment.wso2isAnalyticsWorker1.imageTag }}
         {{- end }}
         env:
         -
@@ -77,32 +95,32 @@ spec:
               fieldPath: status.podIP
         resources:
           requests:
-            memory: {{ .Values.wso2.deployment.wso2isAnalyticsWorker.resources.requests.memory }}
-            cpu: {{ .Values.wso2.deployment.wso2isAnalyticsWorker.resources.requests.cpu }}
+            memory: {{ .Values.wso2.deployment.wso2isAnalyticsWorker1.resources.requests.memory }}
+            cpu: {{ .Values.wso2.deployment.wso2isAnalyticsWorker1.resources.requests.cpu }}
           limits:
-            memory: {{ .Values.wso2.deployment.wso2isAnalyticsWorker.resources.limits.memory }}
-            cpu: {{ .Values.wso2.deployment.wso2isAnalyticsWorker.resources.limits.cpu }}
+            memory: {{ .Values.wso2.deployment.wso2isAnalyticsWorker1.resources.limits.memory }}
+            cpu: {{ .Values.wso2.deployment.wso2isAnalyticsWorker1.resources.limits.cpu }}
         livenessProbe:
           exec:
             command:
             - /bin/sh
             - -c
             - nc -z localhost 9091
-          initialDelaySeconds: {{ default 200 .Values.wso2.deployment.wso2isAnalyticsWorker.livenessProbe.initialDelaySeconds }}
-          periodSeconds: {{ default 10 .Values.wso2.deployment.wso2isAnalyticsWorker.livenessProbe.periodSeconds }}
+          initialDelaySeconds: {{ default 200 .Values.wso2.deployment.wso2isAnalyticsWorker1.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 10 .Values.wso2.deployment.wso2isAnalyticsWorker1.livenessProbe.periodSeconds }}
         readinessProbe:
           exec:
             command:
               - /bin/sh
               - -c
-              - nc -z localhost 7712
-          initialDelaySeconds: {{ default 200 .Values.wso2.deployment.wso2isAnalyticsWorker.readinessProbe.initialDelaySeconds }}
-          periodSeconds: {{ default 10 .Values.wso2.deployment.wso2isAnalyticsWorker.readinessProbe.periodSeconds }}
+              - nc -z localhost 9091
+          initialDelaySeconds: {{ default 200 .Values.wso2.deployment.wso2isAnalyticsWorker1.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 10 .Values.wso2.deployment.wso2isAnalyticsWorker1.readinessProbe.periodSeconds }}
         lifecycle:
           preStop:
             exec:
               command:  ['sh', '-c', '${WSO2_SERVER_HOME}/bin/worker.sh stop']
-        imagePullPolicy: {{ default "Always" .Values.wso2.deployment.wso2isAnalyticsWorker.imagePullPolicy }}
+        imagePullPolicy: {{ default "Always" .Values.wso2.deployment.wso2isAnalyticsWorker1.imagePullPolicy }}
         securityContext:
           runAsUser: 802
         ports:
@@ -133,9 +151,23 @@ spec:
           -
             containerPort: 7443
             protocol: TCP
+          {{ if .Values.wso2.monitoring.enabled }}
+          - containerPort: 2222
+            protocol: TCP
+            name: metrics
+          {{ end }}
         volumeMounts:
         - name: is-analytics-worker-conf
           mountPath: /home/wso2carbon/wso2-config-volume/conf/worker
+        {{ if .Values.wso2.monitoring.enabled }}
+        - name: shared-prometheus-jmx-jar
+          mountPath: /home/wso2carbon/prometheus
+        - name: identity-server-prometheus-exporter-conf
+          mountPath: /home/wso2carbon/prometheus/config.yaml
+          subPath: config.yaml
+        - name: is-analytics-worker-carbon-conf
+          mountPath: /home/wso2carbon/wso2-config-volume/wso2/worker/bin
+        {{ end }}
       {{ if .Values.wso2.centralizedLogging.enabled }}
         - name: shared-logs
           mountPath: /home/wso2carbon/wso2is-analytics-5.8.0/wso2/worker/logs
@@ -154,7 +186,7 @@ spec:
             mountPath: /usr/share/logstash/plugins/
         env:
           - name: NODE_ID
-            value: {{ .Release.Name }}-analytics-worker-node
+            value: {{ .Release.Name }}-analytics-worker-node-1
           - name: NODE_IP
             valueFrom:
               fieldRef:
@@ -173,9 +205,9 @@ spec:
             value: {{ default "wso2-elasticsearch-master" .Values.wso2.centralizedLogging.logstash.elasticsearch.host }}
       {{ end }}
       serviceAccountName: {{ .Values.kubernetes.svcaccount }}
-      {{- if .Values.wso2.deployment.wso2isAnalyticsWorker.imagePullSecrets }}
+      {{- if .Values.wso2.deployment.wso2isAnalyticsWorker1.imagePullSecrets }}
       imagePullSecrets:
-      - name: {{ .Values.wso2.deployment.wso2isAnalyticsWorker.imagePullSecrets }}
+      - name: {{ .Values.wso2.deployment.wso2isAnalyticsWorker1.imagePullSecrets }}
       {{- else if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
       imagePullSecrets:
       - name: wso2creds
@@ -199,3 +231,14 @@ spec:
         secret:
           secretName: logstash-elasticsearch-creds
       {{ end }}
+      {{ if .Values.wso2.monitoring.enabled }}
+      - name: shared-prometheus-jmx-jar
+        emptyDir: {}
+      - name: identity-server-prometheus-exporter-conf
+        configMap:
+          name: identity-server-prometheus-exporter-conf
+      - name: is-analytics-worker-carbon-conf
+        configMap:
+          name: is-analytics-worker-carbon-conf
+      {{ end }}
+

--- a/advanced/helm/is-pattern-2/templates/analytics-worker/identity-server-analytics-worker-1-service.yaml
+++ b/advanced/helm/is-pattern-2/templates/analytics-worker/identity-server-analytics-worker-1-service.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+# Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,24 +15,36 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}-service
+  name: {{ template "fullname" . }}-analytics-worker-1-service
   namespace : {{ .Release.Namespace }}
   labels:
-    deployment: wso2is
-    app: wso2is
+    app: is-pattern-2
     monitoring: {{ default "jmx" .Values.wso2.monitoring.prometheus.jmxJobName }}
+    node: node-1
 spec:
   selector:
-    deployment: wso2is
-    app: wso2is
+    deployment: {{ template "fullname" . }}-analytics-worker
+    node: node-1
   ports:
-  - name: servlet-http
-    port: 9763
-    targetPort: 9763
-    protocol: TCP
   - name: servlet-https
-    port: 9443
-    targetPort: 9443
+    port: 9091
+    targetPort: 9091
+    protocol: TCP
+  - name: siddhi-1
+    port: 7070
+    targetPort: 8082
+    protocol: TCP
+  - name: siddhi-2
+    port: 7443
+    targetPort: 11501
+    protocol: TCP
+  - name: data-reciver-1
+    port: 7612
+    targetPort: 7612
+    protocol: TCP
+  - name: data-receiver-2
+    port: 7712
+    targetPort: 7712
     protocol: TCP
   {{ if .Values.wso2.monitoring.enabled }}
   - name: metrics

--- a/advanced/helm/is-pattern-2/templates/analytics-worker/identity-server-analytics-worker-2-deployment.yaml
+++ b/advanced/helm/is-pattern-2/templates/analytics-worker/identity-server-analytics-worker-2-deployment.yaml
@@ -15,26 +15,27 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}-analytics-dashboard-deployment
+  name: {{ template "fullname" . }}-analytics-worker-2-deployment
   namespace : {{ .Release.Namespace }}
 spec:
-  replicas: {{ default 2 .Values.wso2.deployment.wso2isAnalyticsDashboard.replicas }}
+  replicas: {{ default 1 .Values.wso2.deployment.wso2isAnalyticsWorker2.replicas }}
   strategy:
     rollingUpdate:
-      maxSurge: {{ default 1 .Values.wso2.deployment.wso2isAnalyticsDashboard.strategy.rollingUpdate.maxSurge }}
-      maxUnavailable: {{ default 0 .Values.wso2.deployment.wso2isAnalyticsDashboard.strategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ default 1 .Values.wso2.deployment.wso2isAnalyticsWorker2.strategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ default 0 .Values.wso2.deployment.wso2isAnalyticsWorker2.strategy.rollingUpdate.maxUnavailable }}
     type: RollingUpdate
   selector:
     matchLabels:
-      deployment: {{ template "fullname" . }}-analytics-dashboard
+      deployment: {{ template "fullname" . }}-analytics-worker
       app: is-pattern-2
       monitoring: {{ default "jmx" .Values.wso2.monitoring.prometheus.jmxJobName }}
   template:
     metadata:
       labels:
-        deployment: {{ template "fullname" . }}-analytics-dashboard
+        deployment: {{ template "fullname" . }}-analytics-worker
         app: is-pattern-2
         monitoring: {{ default "jmx" .Values.wso2.monitoring.prometheus.jmxJobName }}
+        node: node-2
     spec:
       initContainers:
       {{ if .Values.wso2.mysql.enabled }}
@@ -72,55 +73,105 @@ spec:
             mountPath: /jmx-jar
       {{ end }}
       containers:
-      - name: {{ template "fullname" . }}-analytics-dashboard
-        {{- if .Values.wso2.deployment.wso2isAnalyticsDashboard.dockerRegistry }}
-        image: {{ .Values.wso2.deployment.wso2isAnalyticsDashboard.dockerRegistry }}/{{ default "wso2is-analytics-dashboard" .Values.wso2.deployment.wso2isAnalyticsDashboard.imageName }}
-        {{- $tag := .Values.wso2.deployment.wso2isAnalyticsDashboard.imageTag }}
+      - name: {{ template "fullname" . }}-analytics-worker
+        {{- if .Values.wso2.deployment.wso2isAnalyticsWorker2.dockerRegistry }}
+        image: {{ .Values.wso2.deployment.wso2isAnalyticsWorker2.dockerRegistry }}/{{ default "wso2is-analytics-worker" .Values.wso2.deployment.wso2isAnalyticsWorker2.imageName }}
+        {{- $tag := .Values.wso2.deployment.wso2isAnalyticsWorker2.imageTag }}
         {{- if not (eq $tag "") }}{{- printf ":%s" $tag -}}{{- end }}
         {{- else if or (eq .Values.wso2.subscription.username "") (eq .Values.wso2.subscription.password "") }}
-        image: wso2/{{ default "wso2is-analytics-dashboard" .Values.wso2.deployment.wso2isAnalyticsDashboard.imageName }}:{{ default "5.8.0" .Values.wso2.deployment.wso2isAnalyticsDashboard.imageTag }}
+        image: wso2/{{ default "wso2is-analytics-worker" .Values.wso2.deployment.wso2isAnalyticsWorker2.imageName }}:{{ default "5.8.0" .Values.wso2.deployment.wso2isAnalyticsWorker2.imageTag }}
         {{- else }}
-        image: docker.wso2.com/{{ default "wso2is-analytics-dashboard" .Values.wso2.deployment.wso2isAnalyticsDashboard.imageName }}:{{ default "5.8.0" .Values.wso2.deployment.wso2isAnalyticsDashboard.imageTag }}
+        image: docker.wso2.com/{{ default "wso2is-analytics-worker" .Values.wso2.deployment.wso2isAnalyticsWorker2.imageName }}:{{ default "5.8.0" .Values.wso2.deployment.wso2isAnalyticsWorker2.imageTag }}
         {{- end }}
-        imagePullPolicy: {{ default "Always" .Values.wso2.deployment.wso2isAnalyticsDashboard.imagePullPolicy }}
-        ports:
+        env:
         -
-          containerPort: 9643
-          protocol: "TCP"
-        {{ if .Values.wso2.monitoring.enabled }}
-        - containerPort: 2222
-          protocol: TCP
-          name: metrics
-        {{ end }}
+          name: NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: NODE_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        resources:
+          requests:
+            memory: {{ .Values.wso2.deployment.wso2isAnalyticsWorker2.resources.requests.memory }}
+            cpu: {{ .Values.wso2.deployment.wso2isAnalyticsWorker2.resources.requests.cpu }}
+          limits:
+            memory: {{ .Values.wso2.deployment.wso2isAnalyticsWorker2.resources.limits.memory }}
+            cpu: {{ .Values.wso2.deployment.wso2isAnalyticsWorker2.resources.limits.cpu }}
         livenessProbe:
           exec:
             command:
             - /bin/sh
             - -c
-            - nc -z localhost 9643
-        resources:
-          requests:
-            memory: {{ .Values.wso2.deployment.wso2isAnalyticsDashboard.resources.requests.memory }}
-            cpu: {{ .Values.wso2.deployment.wso2isAnalyticsDashboard.resources.requests.cpu }}
-          limits:
-            memory: {{ .Values.wso2.deployment.wso2isAnalyticsDashboard.resources.limits.memory }}
-            cpu: {{ .Values.wso2.deployment.wso2isAnalyticsDashboard.resources.limits.cpu }}
+            - nc -z localhost 9091
+          initialDelaySeconds: {{ default 200 .Values.wso2.deployment.wso2isAnalyticsWorker2.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 10 .Values.wso2.deployment.wso2isAnalyticsWorker2.livenessProbe.periodSeconds }}
+        readinessProbe:
+          exec:
+            command:
+              - /bin/sh
+              - -c
+              - nc -z localhost 9091
+          initialDelaySeconds: {{ default 200 .Values.wso2.deployment.wso2isAnalyticsWorker2.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 10 .Values.wso2.deployment.wso2isAnalyticsWorker2.readinessProbe.periodSeconds }}
+        lifecycle:
+          preStop:
+            exec:
+              command:  ['sh', '-c', '${WSO2_SERVER_HOME}/bin/worker.sh stop']
+        imagePullPolicy: {{ default "Always" .Values.wso2.deployment.wso2isAnalyticsWorker2.imagePullPolicy }}
+        securityContext:
+          runAsUser: 802
+        ports:
+          -
+            containerPort: 9090
+            protocol: TCP
+          -
+            containerPort: 9091
+            protocol: TCP
+          -
+            containerPort: 9543
+            protocol: TCP
+          -
+            containerPort: 9711
+            protocol: TCP
+          -
+            containerPort: 9611
+            protocol: TCP
+          -
+            containerPort: 7712
+            protocol: TCP
+          -
+            containerPort: 7612
+            protocol: TCP
+          -
+            containerPort: 7070
+            protocol: TCP
+          -
+            containerPort: 7443
+            protocol: TCP
+          {{ if .Values.wso2.monitoring.enabled }}
+          - containerPort: 2222
+            protocol: TCP
+            name: metrics
+          {{ end }}
         volumeMounts:
-        - name: is-analytics-dashboard-conf
-          mountPath: "/home/wso2carbon/wso2-config-volume/conf/dashboard"
+        - name: is-analytics-worker-conf
+          mountPath: /home/wso2carbon/wso2-config-volume/conf/worker
         {{ if .Values.wso2.monitoring.enabled }}
         - name: shared-prometheus-jmx-jar
           mountPath: /home/wso2carbon/prometheus
         - name: identity-server-prometheus-exporter-conf
           mountPath: /home/wso2carbon/prometheus/config.yaml
           subPath: config.yaml
-        - name: is-analytics-dashboard-carbon-conf
-          mountPath: /home/wso2carbon/wso2-config-volume/wso2/dashboard/bin
+        - name: is-analytics-worker-carbon-conf
+          mountPath: /home/wso2carbon/wso2-config-volume/wso2/worker/bin
         {{ end }}
       {{ if .Values.wso2.centralizedLogging.enabled }}
         - name: shared-logs
-          mountPath: /home/wso2carbon/wso2is-analytics-5.8.0/wso2/dashboard/logs
-      - name: {{ template "fullname" . }}-analytics-dashboard-logstash
+          mountPath: /home/wso2carbon/wso2is-analytics-5.8.0/wso2/worker/logs
+      - name: {{ template "fullname" . }}-analytics-worker-logstash
         image: docker.elastic.co/logstash/logstash:{{ default "7.2.0" .Values.wso2.centralizedLogging.logstash.imageTag }}
         volumeMounts:
           - name: shared-logs
@@ -135,7 +186,7 @@ spec:
             mountPath: /usr/share/logstash/plugins/
         env:
           - name: NODE_ID
-            value: {{ .Release.Name }}-analytics-dashbaord-node
+            value: {{ .Release.Name }}-analytics-worker-node-2
           - name: NODE_IP
             valueFrom:
               fieldRef:
@@ -154,17 +205,17 @@ spec:
             value: {{ default "wso2-elasticsearch-master" .Values.wso2.centralizedLogging.logstash.elasticsearch.host }}
       {{ end }}
       serviceAccountName: {{ .Values.kubernetes.svcaccount }}
-      {{- if .Values.wso2.deployment.wso2isAnalyticsDashboard.imagePullSecrets }}
+      {{- if .Values.wso2.deployment.wso2isAnalyticsWorker2.imagePullSecrets }}
       imagePullSecrets:
-      - name: {{ .Values.wso2.deployment.wso2isAnalyticsDashboard.imagePullSecrets }}
+      - name: {{ .Values.wso2.deployment.wso2isAnalyticsWorker2.imagePullSecrets }}
       {{- else if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
       imagePullSecrets:
       - name: wso2creds
       {{ end }}
       volumes:
-      - name: is-analytics-dashboard-conf
+      - name: is-analytics-worker-conf
         configMap:
-          name: is-analytics-dashboard-conf
+          name: is-analytics-worker-conf
       {{ if .Values.wso2.centralizedLogging.enabled }}
       - name: shared-logs
         emptyDir: {}
@@ -186,7 +237,7 @@ spec:
       - name: identity-server-prometheus-exporter-conf
         configMap:
           name: identity-server-prometheus-exporter-conf
-      - name: is-analytics-dashboard-carbon-conf
+      - name: is-analytics-worker-carbon-conf
         configMap:
-          name: is-analytics-dashboard-carbon-conf
+          name: is-analytics-worker-carbon-conf
       {{ end }}

--- a/advanced/helm/is-pattern-2/templates/analytics-worker/identity-server-analytics-worker-2-service.yaml
+++ b/advanced/helm/is-pattern-2/templates/analytics-worker/identity-server-analytics-worker-2-service.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+# Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,24 +15,36 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "fullname" . }}-service
+  name: {{ template "fullname" . }}-analytics-worker-2-service
   namespace : {{ .Release.Namespace }}
   labels:
-    deployment: wso2is
-    app: wso2is
+    app: is-pattern-2
     monitoring: {{ default "jmx" .Values.wso2.monitoring.prometheus.jmxJobName }}
+    node: node-2
 spec:
   selector:
-    deployment: wso2is
-    app: wso2is
+    deployment: {{ template "fullname" . }}-analytics-worker
+    node: node-2
   ports:
-  - name: servlet-http
-    port: 9763
-    targetPort: 9763
-    protocol: TCP
   - name: servlet-https
-    port: 9443
-    targetPort: 9443
+    port: 9091
+    targetPort: 9091
+    protocol: TCP
+  - name: siddhi-1
+    port: 7070
+    targetPort: 8082
+    protocol: TCP
+  - name: siddhi-2
+    port: 7443
+    targetPort: 11501
+    protocol: TCP
+  - name: data-reciver-1
+    port: 7612
+    targetPort: 7612
+    protocol: TCP
+  - name: data-receiver-2
+    port: 7712
+    targetPort: 7712
     protocol: TCP
   {{ if .Values.wso2.monitoring.enabled }}
   - name: metrics

--- a/advanced/helm/is-pattern-2/templates/analytics-worker/is-analytics-worker-carbon-conf.yaml
+++ b/advanced/helm/is-pattern-2/templates/analytics-worker/is-analytics-worker-carbon-conf.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+# Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,18 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-{{ if .Values.wso2.monitoring.enabled }}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
-    name: identity-server-prometheus-exporter-conf
-    namespace : {{ .Release.Namespace }}
+  name: is-analytics-worker-carbon-conf
+  namespace : {{ .Release.Namespace }}
 data:
-    config.yaml: |
-        startDelaySeconds: 0
-        jmxurl: service:jmx:rmi://localhost:11111/jndi/rmi://localhost:9999/jmxrmi
-        ssl: false
-        rules:
-            - pattern: ".*"
+  {{- $file := .Files }}
+  {{- range $path, $byte := .Files.Glob "confs/is-analytics-worker/wso2/worker/bin/*" }}
+  {{- $list := $path | splitList "/"}}
+  {{- $length := len $list }}
+  {{- $last := add $length -1 }}
+  {{ index $list $last }}: |-
+    {{- range $file.Lines $path }}
+      {{ . }}
+    {{- end }}
+  {{- end }}
 
-{{ end }}

--- a/advanced/helm/is-pattern-2/templates/identity-server-prometheus-exporter-conf.yaml
+++ b/advanced/helm/is-pattern-2/templates/identity-server-prometheus-exporter-conf.yaml
@@ -24,5 +24,4 @@ data:
         ssl: false
         rules:
             - pattern: ".*"
-
 {{ end }}

--- a/advanced/helm/is-pattern-2/templates/identity-server-prometheus-jmx-monitoring.yaml
+++ b/advanced/helm/is-pattern-2/templates/identity-server-prometheus-jmx-monitoring.yaml
@@ -12,17 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 {{ if .Values.wso2.monitoring.enabled }}
-apiVersion: v1
-kind: ConfigMap
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
 metadata:
-    name: identity-server-prometheus-exporter-conf
-    namespace : {{ .Release.Namespace }}
-data:
-    config.yaml: |
-        startDelaySeconds: 0
-        jmxurl: service:jmx:rmi://localhost:11111/jndi/rmi://localhost:9999/jmxrmi
-        ssl: false
-        rules:
-            - pattern: ".*"
-
+    name: identity-server-prometheus-jmx-monitoring
+    namespace: {{ .Release.Namespace }}
+    labels:
+        {{- range $key, $value := .Values.wso2.monitoring.prometheus.serviceMonitor.labels  }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+spec:
+    jobLabel: monitoring
+    selector:
+        matchLabels:
+            app: is-pattern-2
+    Namespace Selector:
+        Match Names:
+            - {{ .Release.Namespace }}
+    endpoints:
+        - port: metrics
+          interval: 1s
+          Path:  /metrics
 {{ end }}

--- a/advanced/helm/is-pattern-2/templates/is/identity-server-conf-event-publishers.yaml
+++ b/advanced/helm/is-pattern-2/templates/is/identity-server-conf-event-publishers.yaml
@@ -20,13 +20,14 @@ metadata:
 data:
   {{- $file := .Files }}
   {{- $fullname := include "fullname" . }}
-  {{- $analyticsWorkerService := printf "%s%s" $fullname "-analytics-worker-service" }}
+  {{- $analyticsWorkerService1 := printf "%s%s" $fullname "-analytics-worker-1-service" }}
+  {{- $analyticsWorkerService2 := printf "%s%s" $fullname "-analytics-worker-2-service" }}
   {{- range $path, $byte := .Files.Glob "confs/is/deployment/server/eventpublishers/*" }}
   {{- $list := $path | splitList "/"}}
   {{- $length := len $list }}
   {{- $last := add $length -1 }}
   {{ index $list $last }}: |-
     {{- range $line := $file.Lines $path }}
-          {{ $line | replace "{{ ANALYTICS_WORKER_SERVICE }}" $analyticsWorkerService }}
+          {{ $line | replace "{{ ANALYTICS_WORKER_SERVICE-1 }}" $analyticsWorkerService1 | replace "{{ ANALYTICS_WORKER_SERVICE-2 }}" $analyticsWorkerService2 }}
     {{- end }}
   {{- end }}

--- a/advanced/helm/is-pattern-2/templates/is/identity-server-deployment.yaml
+++ b/advanced/helm/is-pattern-2/templates/is/identity-server-deployment.yaml
@@ -15,7 +15,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: wso2is-deployment
+  name: wso2is-pattern-2-is-deployment
   namespace : {{ .Release.Namespace }}
 spec:
   replicas: {{ default 1 .Values.wso2.deployment.wso2is.replicas }}
@@ -28,10 +28,14 @@ spec:
   selector:
     matchLabels:
       deployment: wso2is
+      app: is-pattern-2
+      monitoring: {{ default "jmx" .Values.wso2.monitoring.prometheus.jmxJobName }}
   template:
     metadata:
       labels:
         deployment: wso2is
+        app: is-pattern-2
+        monitoring: {{ default "jmx" .Values.wso2.monitoring.prometheus.jmxJobName }}
     spec:
       initContainers:
       {{ if .Values.wso2.mysql.enabled }}
@@ -39,6 +43,12 @@ spec:
         image: busybox:1.31
         command: ['sh', '-c', 'echo -e "Checking for the availability of MySQL Server deployment"; while ! nc -z {{ default "wso2is-rdbms-service-mysql" .Values.wso2.mysql.host }} 3306; do sleep 1; printf "-"; done; echo -e "  >> MySQL Server has started";']
       {{ end }}
+      - name: init-analytics-1
+        image: busybox:1.31
+        command: ['sh', '-c', 'echo -e "Checking for the availability of Analytics Server 1 deployment"; while ! nc -z {{ template "fullname" . }}-analytics-worker-1-service 9091; do sleep 1; printf "-"; done; echo -e "  >> Analytics Server 1 has started";']
+      - name: init-analytics-2
+        image: busybox:1.31
+        command: ['sh', '-c', 'echo -e "Checking for the availability of Analytics Server 2 deployment"; while ! nc -z {{ template "fullname" . }}-analytics-worker-2-service 9091; do sleep 1; printf "-"; done; echo -e "  >> Analytics Server 2 has started";']
       {{ if .Values.wso2.centralizedLogging.enabled }}
       - name: init-logstash-plugins-install
         image: docker.elastic.co/logstash/logstash:{{ default "7.2.0" .Values.wso2.centralizedLogging.logstash.imageTag }}
@@ -54,6 +64,19 @@ spec:
       - name: init-elasticsearch
         image: busybox:1.31
         command: ['sh', '-c', 'echo -e "Checking for the availability of Elasticsearch Server deployment"; while ! nc -z {{ default "wso2-elasticsearch-master" .Values.wso2.centralizedLogging.logstash.elasticsearch.host }} 9200; do sleep 1; printf "-"; done; echo -e "  >> Elasticsearch server has started";']
+      {{ end }}
+      {{ if .Values.wso2.monitoring.enabled }}
+      - name: init-jmx-exporter
+        image: busybox:1.31
+        command:
+          - /bin/sh
+          - "-c"
+          - |
+            set -e
+            wget https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.12.0/jmx_prometheus_javaagent-0.12.0.jar -P /jmx-jar/
+        volumeMounts:
+          - name: shared-prometheus-jmx-jar
+            mountPath: /jmx-jar
       {{ end }}
       containers:
       - name: wso2is
@@ -101,6 +124,11 @@ spec:
           protocol: TCP
         - containerPort: 9443
           protocol: TCP
+        {{ if .Values.wso2.monitoring.enabled }}
+        - containerPort: 2222
+          protocol: TCP
+          name: metrics
+        {{ end }}
         volumeMounts:
         - name: identity-server-conf
           mountPath: /home/wso2carbon/wso2-config-volume/repository/conf
@@ -125,10 +153,15 @@ spec:
         - name: identity-server-conf-entrypoint
           mountPath: /home/wso2carbon/entrypoint.sh
           subPath: docker-entrypoint.sh
-      {{ if not .Values.wso2.deployment.wso2is.hostnameVerificationEnabled }}
+        {{ if .Values.wso2.monitoring.enabled }}
+        - name: shared-prometheus-jmx-jar
+          mountPath: /home/wso2carbon/prometheus
+        - name: identity-server-prometheus-exporter-conf
+          mountPath: /home/wso2carbon/prometheus/config.yaml
+          subPath: config.yaml
         - name: identity-server-bin
           mountPath: /home/wso2carbon/wso2-config-volume/bin
-      {{ end }}
+        {{ end }}
       {{ if .Values.wso2.centralizedLogging.enabled }}
         - name: shared-logs
           mountPath: /home/wso2carbon/wso2is-5.8.0/repository/logs/
@@ -208,11 +241,6 @@ spec:
         configMap:
           name: identity-server-conf-entrypoint
           defaultMode: 0407
-      {{ if not .Values.wso2.deployment.wso2is.hostnameVerificationEnabled }}
-      - name: identity-server-bin
-        configMap:
-          name: identity-server-bin
-      {{ end }}
       {{ if .Values.wso2.centralizedLogging.enabled }}
       - name: shared-logs
         emptyDir: {}
@@ -227,4 +255,14 @@ spec:
       - name: logstash-elasticsearch-creds
         secret:
           secretName: logstash-elasticsearch-creds
+      {{ end }}
+      {{ if .Values.wso2.monitoring.enabled }}
+      - name: shared-prometheus-jmx-jar
+        emptyDir: {}
+      - name: identity-server-prometheus-exporter-conf
+        configMap:
+          name: identity-server-prometheus-exporter-conf
+      - name: identity-server-bin
+        configMap:
+          name: identity-server-bin
       {{ end }}

--- a/advanced/helm/is-pattern-2/templates/is/identity-server-is-prometheus-blackbox-monitoring.yaml
+++ b/advanced/helm/is-pattern-2/templates/is/identity-server-is-prometheus-blackbox-monitoring.yaml
@@ -15,7 +15,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
- name: identity-server-prometheus-blackbox-monitoring
+ name: identity-server-is-prometheus-blackbox-monitoring
  namespace: {{ if .Values.wso2.monitoring.prometheus.serviceMonitor.blackBoxNamespace }}{{ .Values.wso2.monitoring.prometheus.serviceMonitor.blackBoxNamespace  }}{{ else }}{{ .Release.Namespace }}{{ end }}
  labels:
     {{- range $key, $value := .Values.wso2.monitoring.prometheus.serviceMonitor.labels  }}
@@ -41,13 +41,13 @@ spec:
           - sourceLabels:
                 - __param_target
             targetLabel: instance
-          - replacement: https://{{ template "fullname" . }}-service:9443/carbon/admin/login.jsp
+          - replacement: https://{{ template "fullname" . }}-service.{{ .Release.Namespace }}.svc.cluster.local:9443/carbon/admin/login.jsp
             targetLabel: target
       params:
           module:
               - http_2xx
           target:
-              - https://{{ template "fullname" . }}-service:9443/carbon/admin/login.jsp
+              - https://{{ template "fullname" . }}-service.{{ .Release.Namespace }}.svc.cluster.local:9443/carbon/admin/login.jsp
       path: /probe
       port: http
       scheme: http

--- a/advanced/helm/is-pattern-2/templates/is/identity-server-service.yaml
+++ b/advanced/helm/is-pattern-2/templates/is/identity-server-service.yaml
@@ -17,6 +17,9 @@ kind: Service
 metadata:
   name: {{ template "fullname" . }}-service
   namespace : {{ .Release.Namespace }}
+  labels:
+    app: is-pattern-2
+    monitoring: {{ default "jmx" .Values.wso2.monitoring.prometheus.jmxJobName }}
 spec:
   selector:
     deployment: wso2is
@@ -29,3 +32,9 @@ spec:
     port: 9443
     targetPort: 9443
     protocol: TCP
+  {{ if .Values.wso2.monitoring.enabled }}
+  - name: metrics
+    port: 2222
+    targetPort: 2222
+    protocol: TCP
+  {{ end }}

--- a/advanced/helm/is-pattern-2/values.yaml
+++ b/advanced/helm/is-pattern-2/values.yaml
@@ -107,11 +107,51 @@ wso2:
           cpu: "2000m"
       # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
       imagePullPolicy: Always
-    wso2isAnalyticsWorker:
+    wso2isAnalyticsWorker1:
       imageName: "wso2is-analytics-worker"
       imageTag: "5.8.0"
       # Number of deployment replicas
-      replicas: 2
+      replicas: 1
+      strategy:
+        rollingUpdate:
+          # The maximum number of pods that can be scheduled above the desired number of pods.
+          maxSurge: 1
+          # The maximum number of pods that can be unavailable during the update.
+          maxUnavailable: 0
+      # Indicates whether the container is running.
+      livenessProbe:
+        # Number of seconds after the container has started before liveness probes are initiated.
+        initialDelaySeconds: 200
+        # How often (in seconds) to perform the probe.
+        periodSeconds: 10
+      # Indicates whether the container is ready to service requests.
+      readinessProbe:
+        # Number of seconds after the container has started before readiness probes are initiated.
+        initialDelaySeconds: 200
+        # How often (in seconds) to perform the probe.
+        periodSeconds: 10
+      resources:
+        # These are the minimum resource recommendations for running WSO2 Stream Processing based server profiles
+        # as per official documentation (https://docs.wso2.com/display/SP440/Installation+Prerequisites).
+        requests:
+          # The minimum amount of memory that should be allocated for a Pod
+          memory: "4Gi"
+          # The minimum amount of CPU that should be allocated for a Pod
+          cpu: "2000m"
+        # Please see the official documentation on WSO2 Stream Processing based Performance Analysis and Resource recommendations
+        # (https://docs.wso2.com/display/SP440/Performance+Analysis+Results) and tune the limits according to your needs
+        # where necessary.
+        limits:
+          # The maximum amount of memory that should be allocated for a Pod
+          memory: "4Gi"
+          # The maximum amount of CPU that should be allocated for a Pod
+          cpu: "2000m"
+      imagePullPolicy: Always
+    wso2isAnalyticsWorker2:
+      imageName: "wso2is-analytics-worker"
+      imageTag: "5.8.0"
+      # Number of deployment replicas
+      replicas: 1
       strategy:
         rollingUpdate:
           # The maximum number of pods that can be scheduled above the desired number of pods.
@@ -158,12 +198,21 @@ wso2:
         host: "wso2-elasticsearch-master"
         username: "elastic"
         password: "changeme"
-      readinessProbe:
-        initialDelaySeconds: 20
-        periodSeconds: 30
-      livenessProbe:
-        initialDelaySeconds: 20
-        periodSeconds: 30
+  # Configurations for Prometheus monitoring
+  monitoring:
+    # Enable Prometheus monitoring. This will start Prometheus exporter on port 2222 and deploy Service monitors
+    # for JVM, JMX and Blackbox exporter for Login calls
+    enabled: false
+    prometheus:
+      serviceMonitor:
+        # If the black box exporter is deployed in a different Name space
+#        blackBoxNamespace:
+
+        # Prometheus Operator labels to identify Service monitors
+        labels:
+          release: monitoring
+      # Job name of the JMX events
+      jmxJobName: "jmx"
 
 kubernetes:
   # Name of Kubernetes service account


### PR DESCRIPTION
## Purpose
> This PR fixes #143 and expose Analytics worker nodes with separate services instead of a single service.

## Approach
> 
- Introduce new parameters in Values.yaml for monitoring 
- Download Prometheus JMX exporter and configure it with Init containers
- Deploy [ServiceMonitors](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor) to register pods in the Prometheus

## Test environment
> Helm version: v2.14.1
Kubernetes version: v1.12.8-gke.10
 
