### PR TITLE
Use fully qualified  service name

### DIFF
--- a/advanced/helm/is-pattern-1/templates/is/identity-server-prometheus-blackbox-serviceMonitor.yaml
+++ b/advanced/helm/is-pattern-1/templates/is/identity-server-prometheus-blackbox-serviceMonitor.yaml
@@ -41,13 +41,13 @@ spec:
           - sourceLabels:
                 - __param_target
             targetLabel: instance
-          - replacement: https://{{ template "fullname" . }}-service:9443/carbon/admin/login.jsp
+          - replacement: https://{{ template "fullname" . }}-service.{{ .Release.Namespace }}.svc.cluster.local:9443/carbon/admin/login.jsp
             targetLabel: target
       params:
           module:
               - http_2xx
           target:
-              - https://{{ template "fullname" . }}-service:9443/carbon/admin/login.jsp
+              - https://{{ template "fullname" . }}-service.{{ .Release.Namespace }}.svc.cluster.local:9443/carbon/admin/login.jsp
       path: /probe
       port: http
       scheme: http


### PR DESCRIPTION
## Purpose
Use fully qualified name to identify service since the blackbox exporter might be in a different namespace than the service.