### PR TITLE
Add WSO2 helm chart prerequisite in documentation

### DIFF
--- a/advanced/helm/is-pattern-1/README.md
+++ b/advanced/helm/is-pattern-1/README.md
@@ -19,6 +19,11 @@ steps provided in the following quick start guide.<br><br>
 
 * Install [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/). Please note that Helm resources for WSO2 product
 deployment patterns are compatible with NGINX Ingress Controller Git release [`nginx-0.22.0`](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.22.0).
+
+* Add the WSO2 Helm chart repository
+```
+ helm repo add wso2 https://helm.wso2.com && helm repo update
+```
   
 ## Quick Start Guide
 >In the context of this document, <br>

--- a/advanced/helm/is-pattern-2/README.md
+++ b/advanced/helm/is-pattern-2/README.md
@@ -19,6 +19,11 @@ steps provided in the following quick start guide.<br><br>
 
 * Install [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/).Please note that Helm resources for WSO2 product
 deployment patterns are compatible with NGINX Ingress Controller Git release [`nginx-0.22.0`](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.22.0).
+
+* Add the WSO2 Helm chart repository
+```
+ helm repo add wso2 https://helm.wso2.com && helm repo update
+```
   
 ## Quick Start Guide
 >In the context of this document, <br>


### PR DESCRIPTION
## Goals
> Add WSO2 helm chart prerequisite in documentation

## Test environment
> Helm version: v2.14.2
> Kubernetes version: v1.12.8-gke.10