### PR TITLE
Fix empty value provided to localMemberHost in clustering configurations

### DIFF
--- a/advanced/helm/is-pattern-1/templates/identity-server-conf-entrypoint.yaml
+++ b/advanced/helm/is-pattern-1/templates/identity-server-conf-entrypoint.yaml
@@ -40,7 +40,7 @@ data:
 
     # make any node specific configuration changes
     # for example, set the Docker container IP as the `localMemberHost` under axis2.xml clustering configurations (effective only when clustering is enabled)
-    sed -i "s#<parameter\ name=\"localMemberHost\".*<\/parameter>#<parameter\ name=\"localMemberHost\">${docker_container_ip}<\/parameter>#" ${WSO2_SERVER_HOME}/repository/conf/axis2/axis2.xml
+    sed -i "s#<parameter\ name=\"localMemberHost\".*<\/parameter>#<parameter\ name=\"localMemberHost\">${NODE_IP}<\/parameter>#" ${WSO2_SERVER_HOME}/repository/conf/axis2/axis2.xml
 
     # start WSO2 Carbon server
     sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/advanced/helm/is-pattern-1/templates/is/identity-server-deployment.yaml
+++ b/advanced/helm/is-pattern-1/templates/is/identity-server-deployment.yaml
@@ -114,6 +114,11 @@ spec:
               command:  ['sh', '-c', '${WSO2_SERVER_HOME}/bin/wso2server.sh stop']
         securityContext:
           runAsUser: 802
+        env:
+          - name: NODE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
         ports:
         - containerPort: 9763
           protocol: TCP

--- a/advanced/helm/is-pattern-2/templates/identity-server-conf-entrypoint.yaml
+++ b/advanced/helm/is-pattern-2/templates/identity-server-conf-entrypoint.yaml
@@ -40,7 +40,7 @@ data:
 
     # make any node specific configuration changes
     # for example, set the Docker container IP as the `localMemberHost` under axis2.xml clustering configurations (effective only when clustering is enabled)
-    sed -i "s#<parameter\ name=\"localMemberHost\".*<\/parameter>#<parameter\ name=\"localMemberHost\">${docker_container_ip}<\/parameter>#" ${WSO2_SERVER_HOME}/repository/conf/axis2/axis2.xml
+    sed -i "s#<parameter\ name=\"localMemberHost\".*<\/parameter>#<parameter\ name=\"localMemberHost\">${NODE_IP}<\/parameter>#" ${WSO2_SERVER_HOME}/repository/conf/axis2/axis2.xml
 
     # start WSO2 Carbon server
     sh ${WSO2_SERVER_HOME}/bin/wso2server.sh "$@"

--- a/advanced/helm/is-pattern-2/templates/is/identity-server-deployment.yaml
+++ b/advanced/helm/is-pattern-2/templates/is/identity-server-deployment.yaml
@@ -106,6 +106,7 @@ spec:
           initialDelaySeconds: {{ default 250 .Values.wso2.deployment.wso2is.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ default 10 .Values.wso2.deployment.wso2is.readinessProbe.periodSeconds }}
         imagePullPolicy: {{ default "Always" .Values.wso2.deployment.wso2is.imagePullPolicy }}
+        command: ["/home/wso2carbon/entrypoint.sh"]
         resources:
           requests:
             memory: {{ .Values.wso2.deployment.wso2is.resources.requests.memory }}
@@ -119,6 +120,11 @@ spec:
               command:  ['sh', '-c', '${WSO2_SERVER_HOME}/bin/wso2server.sh stop']
         securityContext:
           runAsUser: 802
+        env:
+          - name: NODE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
         ports:
         - containerPort: 9763
           protocol: TCP


### PR DESCRIPTION
## Purpose
> Resolves #182  

## Goals
> Fix empty value provided to "localMemberHost" in clustering configurations

## Test environment
> Helm version: v2.14.2
> Kubernetes version: v1.12.8-gke.10