### PR TITLE
Use backend protocol HTTPS and disable SSL-passthrough for ingress

### DIFF
--- a/advanced/is-pattern-1/templates/identity-server-ingress.yaml
+++ b/advanced/is-pattern-1/templates/identity-server-ingress.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace : {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"

--- a/advanced/is-pattern-2/templates/identity-server-dashboard-ingress.yaml
+++ b/advanced/is-pattern-2/templates/identity-server-dashboard-ingress.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace : {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"

--- a/advanced/is-pattern-2/templates/identity-server-ingress.yaml
+++ b/advanced/is-pattern-2/templates/identity-server-ingress.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace : {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "route"
     nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"


### PR DESCRIPTION
## Purpose
The current implementation of the NGINX ingress resources does not work with the NGINX versions later than 0.22.0 (#198 ). This PR introduces the following changes to add support for this.

- Add annotation `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` to force the backend protocol to be HTTPS.
- Remove annotation `nginx.ingress.kubernetes.io/ssl-passthrough: "true"`
