### PR TITLE
Support for Kubernetes 1.16, Closes #195

### DIFF
--- a/advanced/databases/mysql-is/requirements.yaml
+++ b/advanced/databases/mysql-is/requirements.yaml
@@ -13,5 +13,5 @@
 # limitations under the License.
 dependencies:
   - name: mysql
-    version: "1.3.0"
+    version: "1.6.3"
     repository: "https://kubernetes-charts.storage.googleapis.com"

--- a/advanced/is-pattern-1/requirements.yaml
+++ b/advanced/is-pattern-1/requirements.yaml
@@ -17,6 +17,6 @@ dependencies:
     repository: "https://helm.wso2.com"
     condition: wso2.mysql.enabled
   - name: nfs-server-provisioner
-    version: "0.3.0"
+    version: "1.0.0"
     repository: "https://kubernetes-charts.storage.googleapis.com"
     condition: wso2.deployment.dependencies.nfsServerProvisioner


### PR DESCRIPTION
This ended up being a fairly easy fix.

- Updated NFS server provisioner and MySQL requirements

## Purpose
Closes #195

## Goals
Closing #195

## Approach
Update to newer requirements that support K8s 1.16

## User stories
#195

## Release note
Support for Kubernetes 1.16

## Documentation
N/A - no changes to deployment procedures

## Certification
N/A - does not affect certification

## Automation tests
N/A - Existing tests should be sufficient

## Related PRs
wso2/docker-is#202