### PR TITLE
Allow Specification of Host in Deployment, Closes #222

### DIFF
--- a/advanced/is-pattern-1/README.md
+++ b/advanced/is-pattern-1/README.md
@@ -41,43 +41,22 @@
 [Option 1] Deploy using Docker images from DockerHub.
 
 ```
-helm install --name <RELEASE_NAME> wso2/is-pattern-1 --version 5.10.0-1 --namespace <NAMESPACE>
+helm install --name <RELEASE_NAME> wso2/is-pattern-1 --version 5.10.0-1 --namespace <NAMESPACE> --set wso2.host=<HOST>
 ```
 
 [Option 2] Deploy WSO2 Identity Server using Docker images from WSO2 Private Docker Registry.
 
 ```
-helm install --name <RELEASE_NAME> wso2/is-pattern-1 --version 5.10.0-1 --namespace <NAMESPACE>  --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
+helm install --name <RELEASE_NAME> wso2/is-pattern-1 --version 5.10.0-1 --namespace <NAMESPACE> --set wso2.host=<HOST> --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
 ```     
 **Note:**
 
 * `NAMESPACE` should be the Kubernetes Namespace in which the resources are deployed.
+* `HOST` should be the host you'll use to access the deployment, the default is `localhost`.
 
 ##### 2. Access Management Console.
  
-Default deployment will expose `<RELEASE_NAME>` host (to expose Administrative services and Management Console).
- 
-To access the console in the environment,
- 
- a. Obtain the external IP (`EXTERNAL-IP`) of the Ingress resources by listing down the Kubernetes Ingresses.
- 
- ```
- kubectl get ing -n <NAMESPACE>
- ```
- Output:
- 
- ```
- NAME                       HOSTS                  ADDRESS        PORTS     AGE
- wso2is-ingress             <RELEASE_NAME>         <EXTERNAL-IP>  80, 443   3m
- ```
- 
- b. Add the above host as an entry in `/etc/hosts` file as follows:
-    
- ```
- <EXTERNAL-IP> <RELEASE_NAME>
- ```
- 
- c. Try navigating to `https://<RELEASE_NAME>/carbon` from your favorite browser.
+Navigate to `https://<HOST>/carbon` from your favorite browser.
  
 
 ### Install Chart From Source
@@ -96,52 +75,32 @@ git clone https://github.com/wso2/kubernetes-is.git
 ##### 2. Deploy Helm chart for a clustered deployment of WSO2 Identity Server.
 
 ```
-helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/is-pattern-1 --namespace <NAMESPACE>
+helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/is-pattern-1 --namespace <NAMESPACE> --set wso2.host=<HOST>
 ```
 
-`NAMESPACE` should be the Kubernetes Namespace in which the resources are deployed
+* `NAMESPACE` should be the Kubernetes Namespace in which the resources are deployed
+* `HOST` should be the host you'll use to access the deployment, the default is `localhost`.
 
 [Option 1] Deploy using Docker images from DockerHub.
 
 ```
-helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/is-pattern-1 --namespace <NAMESPACE>
+helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/is-pattern-1 --namespace <NAMESPACE> --set wso2.host=<HOST>
 ```
 
 [Option 2] Deploy WSO2 Identity Server using Docker images from WSO2 Private Docker Registry.
 
 ```
-helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/is-pattern-1 --namespace <NAMESPACE>  --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
+helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/is-pattern-1 --namespace <NAMESPACE> --set wso2.host=<HOST> --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
 ```
 
 **Note:**
 
 * `NAMESPACE` should be the Kubernetes Namespace in which the resources are deployed.
+* `HOST` should be the host you'll use to access the deployment, the default is `localhost`.
 
 ##### 3. Access Management Console.
 
-Default deployment will expose `<RELEASE_NAME>` host (to expose Administrative services and Management Console).
- 
-To access the console in the environment,
- 
- a. Obtain the external IP (`EXTERNAL-IP`) of the Ingress resources by listing down the Kubernetes Ingresses.
- 
- ```
- kubectl get ing -n <NAMESPACE>
- ```
- Output:
- 
- ```
- NAME                       HOSTS                  ADDRESS        PORTS     AGE
- wso2is-ingress             <RELEASE_NAME>         <EXTERNAL-IP>  80, 443   3m
- ```
- 
- b. Add the above host as an entry in `/etc/hosts` file as follows:
-    
- ```
- <EXTERNAL-IP> <RELEASE_NAME>
- ```
- 
- c. Try navigating to `https://<RELEASE_NAME>/carbon` from your favorite browser.
+Navigate to `https://<HOST>/carbon` from your favorite browser.
 
 
 ## Configuration
@@ -154,6 +113,12 @@ The following tables lists the configurable parameters of the chart and their de
 |-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|-----------------------------|
 | `wso2.subscription.username`                                                | Your WSO2 Subscription username                                                           | ""                          |
 | `wso2.subscription.password`                                                | Your WSO2 Subscription password                                                           | ""                          |
+
+###### Host
+
+| Parameter                                                                   | Description                                                                               | Default Value               |
+|-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|-----------------------------|
+| `wso2.host`                                                                 | The host you'll use to access the deployment                                              | "localhost"                 |
 
 ###### Chart Dependencies
 

--- a/advanced/is-pattern-1/README.md
+++ b/advanced/is-pattern-1/README.md
@@ -41,13 +41,13 @@
 [Option 1] Deploy using Docker images from DockerHub.
 
 ```
-helm install --name <RELEASE_NAME> wso2/is-pattern-1 --version 5.10.0-1 --namespace <NAMESPACE> --set wso2.host=<HOST>
+helm install --name <RELEASE_NAME> wso2/is-pattern-1 --version 5.10.0-1 --namespace <NAMESPACE> --set wso2.deployment.wso2is.host=<HOST>
 ```
 
 [Option 2] Deploy WSO2 Identity Server using Docker images from WSO2 Private Docker Registry.
 
 ```
-helm install --name <RELEASE_NAME> wso2/is-pattern-1 --version 5.10.0-1 --namespace <NAMESPACE> --set wso2.host=<HOST> --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
+helm install --name <RELEASE_NAME> wso2/is-pattern-1 --version 5.10.0-1 --namespace <NAMESPACE> --set wso2.deployment.wso2is.host=<HOST> --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
 ```     
 **Note:**
 
@@ -75,7 +75,7 @@ git clone https://github.com/wso2/kubernetes-is.git
 ##### 2. Deploy Helm chart for a clustered deployment of WSO2 Identity Server.
 
 ```
-helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/is-pattern-1 --namespace <NAMESPACE> --set wso2.host=<HOST>
+helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/is-pattern-1 --namespace <NAMESPACE> --set wso2.deployment.wso2is.host=<HOST>
 ```
 
 * `NAMESPACE` should be the Kubernetes Namespace in which the resources are deployed
@@ -84,13 +84,13 @@ helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/is-pattern-1 --namespace
 [Option 1] Deploy using Docker images from DockerHub.
 
 ```
-helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/is-pattern-1 --namespace <NAMESPACE> --set wso2.host=<HOST>
+helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/is-pattern-1 --namespace <NAMESPACE> --set wso2.deployment.wso2is.host=<HOST>
 ```
 
 [Option 2] Deploy WSO2 Identity Server using Docker images from WSO2 Private Docker Registry.
 
 ```
-helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/is-pattern-1 --namespace <NAMESPACE> --set wso2.host=<HOST> --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
+helm install --dep-up --name <RELEASE_NAME> <HELM_HOME>/is-pattern-1 --namespace <NAMESPACE> --set wso2.deployment.wso2is.host=<HOST> --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
 ```
 
 **Note:**
@@ -118,7 +118,7 @@ The following tables lists the configurable parameters of the chart and their de
 
 | Parameter                                                                   | Description                                                                               | Default Value               |
 |-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|-----------------------------|
-| `wso2.host`                                                                 | The host you'll use to access the deployment                                              | "localhost"                 |
+| `wso2.deployment.wso2is.host`                                               | The host you'll use to access the deployment                                              | "localhost"                 |
 
 ###### Chart Dependencies
 

--- a/advanced/is-pattern-1/templates/NOTES.txt
+++ b/advanced/is-pattern-1/templates/NOTES.txt
@@ -1,19 +1,5 @@
 Thank you for installing WSO2 Identity Server.
 
-Please follow these steps to access the Management Console in the environment.
-
-1. Obtain the external IP (`EXTERNAL-IP`) of the Ingress resources by listing down the Kubernetes Ingresses.
-
-  kubectl get ing -n {{ .Release.Namespace }}
-
-    NAME                       HOSTS                  ADDRESS        PORTS     AGE
-    wso2is-ingress             {{ .Release.Name }}    <EXTERNAL-IP>  80, 443   3m
-
-2. Add the above host as an entry in /etc/hosts file as follows:
-
-    <EXTERNAL-IP>   {{ .Release.Name }}
-
-3. Navigate to https://{{ .Release.Name }}/carbon in your browser of choice.
-
+Navigate to https://{{ .Values.wso2.host }}/carbon in your browser of choice.
 
 Please refer the official documentation at https://docs.wso2.com/display/IS580/WSO2+Identity+Server+Documentation for additional information on WSO2 Identity Server.

--- a/advanced/is-pattern-1/templates/NOTES.txt
+++ b/advanced/is-pattern-1/templates/NOTES.txt
@@ -1,5 +1,5 @@
 Thank you for installing WSO2 Identity Server.
 
-Navigate to https://{{ .Values.wso2.host }}/carbon in your browser of choice.
+Navigate to https://{{ .Values.wso2.deployment.wso2is.host }}/carbon in your browser of choice.
 
 Please refer the official documentation at https://docs.wso2.com/display/IS580/WSO2+Identity+Server+Documentation for additional information on WSO2 Identity Server.

--- a/advanced/is-pattern-1/templates/is/identity-server-deployment.yaml
+++ b/advanced/is-pattern-1/templates/is/identity-server-deployment.yaml
@@ -125,7 +125,7 @@ spec:
               fieldRef:
                 fieldPath: status.podIP
           - name: HOST_NAME
-            value: {{ .Values.wso2.host }}
+            value: {{ .Values.wso2.deployment.wso2is.host }}
         ports:
         - containerPort: 9763
           protocol: TCP

--- a/advanced/is-pattern-1/templates/is/identity-server-deployment.yaml
+++ b/advanced/is-pattern-1/templates/is/identity-server-deployment.yaml
@@ -125,7 +125,7 @@ spec:
               fieldRef:
                 fieldPath: status.podIP
           - name: HOST_NAME
-            value: {{ .Release.Name }}
+            value: {{ .Values.wso2.host }}
         ports:
         - containerPort: 9763
           protocol: TCP

--- a/advanced/is-pattern-1/templates/is/identity-server-ingress.yaml
+++ b/advanced/is-pattern-1/templates/is/identity-server-ingress.yaml
@@ -27,9 +27,9 @@ metadata:
 spec:
   tls:
   - hosts:
-    - {{ .Values.wso2.host }}
+    - {{ .Values.wso2.deployment.wso2is.host }}
   rules:
-  - host: {{ .Values.wso2.host }}
+  - host: {{ .Values.wso2.deployment.wso2is.host }}
     http:
       paths:
       - path: /

--- a/advanced/is-pattern-1/templates/is/identity-server-ingress.yaml
+++ b/advanced/is-pattern-1/templates/is/identity-server-ingress.yaml
@@ -27,9 +27,9 @@ metadata:
 spec:
   tls:
   - hosts:
-    - {{ .Release.Name }}
+    - {{ .Values.wso2.host }}
   rules:
-  - host: {{ .Release.Name }}
+  - host: {{ .Values.wso2.host }}
     http:
       paths:
       - path: /

--- a/advanced/is-pattern-1/values.yaml
+++ b/advanced/is-pattern-1/values.yaml
@@ -32,9 +32,6 @@ wso2:
     # Exported location on external NFS Server to be mounted at <IS_HOME>/repository/deployment/server/userstores
     sharedUserstores: ""
 
-  # The host for the ingress and HOST_NAME environment variable
-  host: "localhost"
-
   deployment:
 
     dependencies:
@@ -45,6 +42,8 @@ wso2:
       nfsServerProvisioner: true
 
     wso2is:
+      # The host for the ingress and HOST_NAME environment variable
+      host: "localhost"
       # If a custom image must be used, uncomment 'dockerRegistry' and provide its value.
       # dockerRegistry: ""
       imageName: "wso2is"

--- a/advanced/is-pattern-1/values.yaml
+++ b/advanced/is-pattern-1/values.yaml
@@ -32,6 +32,9 @@ wso2:
     # Exported location on external NFS Server to be mounted at <IS_HOME>/repository/deployment/server/userstores
     sharedUserstores: ""
 
+  # The host for the ingress and HOST_NAME environment variable
+  host: "localhost"
+
   deployment:
 
     dependencies:


### PR DESCRIPTION
## Purpose
Closes #222

## Goals
Closing #222

## Approach
- Changed instances of using release name to new `wso2.host` value
- Updated NOTES and README

## User stories
#222

## Release note
Added `wso2.host` value for easier, real-world deployments

## Documentation
README and NOTES are updated as part of the change

## Automation tests
Not sure what automated tests are in place for K8s deployments that may be affected

## Test environment
Kubernetes