### PR TITLE
[v5.10.x] Avoid Packaging the NFS Server Provisioner

### DIFF
--- a/advanced/databases/mysql-is/values.yaml
+++ b/advanced/databases/mysql-is/values.yaml
@@ -17,6 +17,12 @@ mysql:
   mysqlUser: wso2carbon
   mysqlPassword: wso2carbon
   fullnameOverride: "wso2is-mysql-db-service"
+  persistence:
+    storageClass: ""
+  livenessProbe:
+    initialDelaySeconds: 120
+  readinessProbe:
+    initialDelaySeconds: 120
   configurationFiles:
     mysql.cnf: |-
       [mysqld]

--- a/advanced/databases/mysql-is/values.yaml
+++ b/advanced/databases/mysql-is/values.yaml
@@ -17,8 +17,6 @@ mysql:
   mysqlUser: wso2carbon
   mysqlPassword: wso2carbon
   fullnameOverride: "wso2is-mysql-db-service"
-  persistence:
-    storageClass: ""
   livenessProbe:
     initialDelaySeconds: 120
   readinessProbe:

--- a/advanced/databases/mysql-is/values.yaml
+++ b/advanced/databases/mysql-is/values.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 mysql:
-  imageTag: "5.7"
+  imageTag: "5.7.31"
   mysqlRootPassword: root
   mysqlUser: wso2carbon
   mysqlPassword: wso2carbon

--- a/advanced/is-pattern-1/Chart.yaml
+++ b/advanced/is-pattern-1/Chart.yaml
@@ -16,5 +16,5 @@ apiVersion: v1
 appVersion: "5.10.0"
 description: A Helm chart for the deployment of WSO2 Identity And Access Management pattern 1
 name: is-pattern-1
-version: 5.10.0-1
+version: 5.10.0-2
 icon: https://wso2.cachefly.net/wso2/sites/all/images/wso2logo.svg

--- a/advanced/is-pattern-1/requirements.yaml
+++ b/advanced/is-pattern-1/requirements.yaml
@@ -16,7 +16,3 @@ dependencies:
     version: "5.10.0-2"
     repository: "https://helm.wso2.com"
     condition: wso2.mysql.enabled
-  - name: nfs-server-provisioner
-    version: "1.0.0"
-    repository: "https://kubernetes-charts.storage.googleapis.com"
-    condition: wso2.deployment.dependencies.nfsServerProvisioner

--- a/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-statefulset.yaml
+++ b/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-statefulset.yaml
@@ -194,10 +194,10 @@ spec:
       {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.sharedArtifacts.enabled }}
       - name: identity-server-volume-claim-tenants-storage
         persistentVolumeClaim:
-          claimName: {{ template "is-pattern-1.resource.prefix" . }}-identity-server-volume-claim-tenants
+          claimName: {{ template "is-pattern-1.resource.prefix" . }}-identity-server-shared-tenants-volume-claim
       - name: identity-server-volume-claim-userstores-storage
         persistentVolumeClaim:
-          claimName: {{ template "is-pattern-1.resource.prefix" . }}-identity-server-volume-claim-userstores
+          claimName: {{ template "is-pattern-1.resource.prefix" . }}-identity-server-shared-userstores-volume-claim
       {{ end }}
       {{ if .Values.wso2.centralizedLogging.enabled }}
       - name: shared-logs

--- a/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-statefulset.yaml
+++ b/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-statefulset.yaml
@@ -79,6 +79,7 @@ spec:
           {{ else }}
           image: docker.wso2.com/{{ .Values.wso2.deployment.wso2is.imageName }}:{{ .Values.wso2.deployment.wso2is.imageTag }}
           {{ end }}
+          imagePullPolicy: {{ .Values.wso2.deployment.wso2is.imagePullPolicy }}
           env:
             - name: NODE_IP
               valueFrom:
@@ -111,7 +112,6 @@ spec:
             limits:
               memory: {{ .Values.wso2.deployment.wso2is.resources.limits.memory }}
               cpu: {{ .Values.wso2.deployment.wso2is.resources.limits.cpu }}
-          imagePullPolicy: {{ .Values.wso2.deployment.wso2is.imagePullPolicy }}
           securityContext:
             runAsUser: 802
           ports:
@@ -128,10 +128,12 @@ spec:
             - name: identity-server-conf
               mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/deployment.toml
               subPath: deployment.toml
+            {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.sharedArtifacts.enabled }}
             - name: identity-server-volume-claim-tenants-storage
               mountPath: /home/wso2carbon/wso2is-5.10.0/repository/tenants
             - name: identity-server-volume-claim-userstores-storage
               mountPath: /home/wso2carbon/wso2is-5.10.0/repository/deployment/server/userstores
+            {{ end }}
             {{ if .Values.wso2.monitoring.enabled }}
             - name: shared-prometheus-jmx-jar
               mountPath: /home/wso2carbon/prometheus
@@ -189,12 +191,14 @@ spec:
       - name: identity-server-conf
         configMap:
           name: {{ template "is-pattern-1.resource.prefix" . }}-identity-server-conf
+      {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.sharedArtifacts.enabled }}
       - name: identity-server-volume-claim-tenants-storage
         persistentVolumeClaim:
           claimName: {{ template "is-pattern-1.resource.prefix" . }}-identity-server-volume-claim-tenants
       - name: identity-server-volume-claim-userstores-storage
         persistentVolumeClaim:
           claimName: {{ template "is-pattern-1.resource.prefix" . }}-identity-server-volume-claim-userstores
+      {{ end }}
       {{ if .Values.wso2.centralizedLogging.enabled }}
       - name: shared-logs
         emptyDir: {}

--- a/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-volume-claims.yaml
+++ b/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-volume-claims.yaml
@@ -1,3 +1,4 @@
+  {{ if .Values.wso2.deployment.persistentRuntimeArtifacts.sharedArtifacts.enabled }}
 # Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +24,7 @@ spec:
   volumeMode: Filesystem
   resources:
     requests:
-      storage: 500M
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.sharedArtifacts.capacity.tenants }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
 
 ---
@@ -39,5 +40,6 @@ spec:
   volumeMode: Filesystem
   resources:
     requests:
-      storage: 500M
+      storage: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.sharedArtifacts.capacity.userstores }}
   storageClassName: {{ .Values.wso2.deployment.persistentRuntimeArtifacts.storageClass }}
+  {{ end }}

--- a/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-volume-claims.yaml
+++ b/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-volume-claims.yaml
@@ -16,7 +16,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ template "is-pattern-1.resource.prefix" . }}-identity-server-volume-claim-tenants
+  name: {{ template "is-pattern-1.resource.prefix" . }}-identity-server-shared-tenants-volume-claim
   namespace : {{ .Release.Namespace }}
 spec:
   accessModes:
@@ -32,7 +32,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ template "is-pattern-1.resource.prefix" . }}-identity-server-volume-claim-userstores
+  name: {{ template "is-pattern-1.resource.prefix" . }}-identity-server-shared-userstores-volume-claim
   namespace : {{ .Release.Namespace }}
 spec:
   accessModes:

--- a/advanced/is-pattern-1/values.yaml
+++ b/advanced/is-pattern-1/values.yaml
@@ -31,12 +31,12 @@ wso2:
       # Kubernetes Storage Class to be used to dynamically provision the relevant Persistent Volumes
       # Only persistent storage solutions supporting ReadWriteMany access mode are applicable (https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes)
       # Mandatory to set if artifact persistence and sharing is enabled (i.e. wso2 -> deployment -> persistentRuntimeArtifacts -> sharedArtifacts -> enabled)
-      storageClass: ""
+      storageClass: &storage_class ""
 
       # Define configurations for persistent runtime artifacts which are shared between instances of the Identity Server profile
       sharedArtifacts:
-        # Enable/Disable persistent runtime artifacts sharing between instances of the Identity Server profile
-        enabled: true
+        # Enable/Disable persistence and sharing of runtime artifacts between instances of the Identity Server profile
+        enabled: false
         # Define capacities for persistent runtime artifacts which are shared between instances of the Identity Server profile
         capacity:
           # For tenant data shared between the Identity Server profile instances
@@ -122,3 +122,9 @@ wso2:
 kubernetes:
   # Name of Kubernetes service account
   serviceAccount: "wso2is-pattern-1-svc-account"
+
+# Override sub chart parameters
+mysql-is:
+  mysql:
+    persistence:
+      storageClass: *storage_class

--- a/advanced/is-pattern-1/values.yaml
+++ b/advanced/is-pattern-1/values.yaml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 wso2:
   # WSO2 Subscription parameters (https://wso2.com/subscription/)
   # If provided, these parameters will be used to obtain official WSO2 product Docker images available at WSO2 Private Docker Registry (https://docker.wso2.com/)
@@ -23,15 +24,25 @@ wso2:
     dependencies:
       # The configuration should be set to be 'true' if a MySQL database should be spawned as a pod within the cluster
       mysql: true
-      # Enable NFS dynamic provisioner for Kubernetes
-      nfsServerProvisioner: true
 
+    # Persisted and shared runtime artifacts for Identity Server
+    # See official documentation (from https://is.docs.wso2.com/en/latest/setup/deployment-guide/#enabling-artifact-synchronization)
     persistentRuntimeArtifacts:
-      # Persistent storage provider expected to be used for sharing persistent runtime artifacts
-      # Must refer to an appropriate Kubernetes Storage Class (https://kubernetes.io/docs/concepts/storage/storage-classes/)
-      # "nfs" (default) - Using the official Kubernetes NFS Server Provisioner (https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner)
-      # This provisioner is installed by default, with this Helm Chart (wso2 -> deployment -> dependencies -> nfsServerProvisioner)
-      storageClass: "nfs"
+      # Kubernetes Storage Class to be used to dynamically provision the relevant Persistent Volumes
+      # Only persistent storage solutions supporting ReadWriteMany access mode are applicable (https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes)
+      # Mandatory to set if artifact persistence and sharing is enabled (i.e. wso2 -> deployment -> persistentRuntimeArtifacts -> sharedArtifacts -> enabled)
+      storageClass: ""
+
+      # Define configurations for persistent runtime artifacts which are shared between instances of the Identity Server profile
+      sharedArtifacts:
+        # Enable/Disable persistent runtime artifacts sharing between instances of the Identity Server profile
+        enabled: true
+        # Define capacities for persistent runtime artifacts which are shared between instances of the Identity Server profile
+        capacity:
+          # For tenant data shared between the Identity Server profile instances
+          tenants: 100M
+          # For secondary user stores shared between the Identity Server profile instances
+          userstores: 50M
 
     wso2is:
       # Hostname for Identity Server

--- a/advanced/is-pattern-1/values.yaml
+++ b/advanced/is-pattern-1/values.yaml
@@ -31,7 +31,7 @@ wso2:
       # Kubernetes Storage Class to be used to dynamically provision the relevant Persistent Volumes
       # Only persistent storage solutions supporting ReadWriteMany access mode are applicable (https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes)
       # Mandatory to set if artifact persistence and sharing is enabled (i.e. wso2 -> deployment -> persistentRuntimeArtifacts -> sharedArtifacts -> enabled)
-      storageClass: &storage_class ""
+      storageClass: "-"
 
       # Define configurations for persistent runtime artifacts which are shared between instances of the Identity Server profile
       sharedArtifacts:
@@ -122,9 +122,3 @@ wso2:
 kubernetes:
   # Name of Kubernetes service account
   serviceAccount: "wso2is-pattern-1-svc-account"
-
-# Override sub chart parameters
-mysql-is:
-  mysql:
-    persistence:
-      storageClass: *storage_class

--- a/advanced/is-pattern-1/values.yaml
+++ b/advanced/is-pattern-1/values.yaml
@@ -12,18 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 wso2:
-
-  # WSO2 subscription parameters. If you do not have an active subscription, do not provide values for the parameters.
-  # If you do not possess an active WSO2 subscription already, you can sign up for a WSO2 Free Trial Subscription at (https://wso2.com/free-trial-subscription).
+  # WSO2 Subscription parameters (https://wso2.com/subscription/)
+  # If provided, these parameters will be used to obtain official WSO2 product Docker images available at WSO2 Private Docker Registry (https://docker.wso2.com/)
+  # for this deployment
   subscription:
     username: ""
     password: ""
 
   deployment:
-
     dependencies:
-      # MySQL configurations
-      # enabled: The configuration should be set to be 'true' if a MySQL database should be spawned as a pod within the cluster
+      # The configuration should be set to be 'true' if a MySQL database should be spawned as a pod within the cluster
       mysql: true
       # Enable NFS dynamic provisioner for Kubernetes
       nfsServerProvisioner: true
@@ -31,44 +29,41 @@ wso2:
     persistentRuntimeArtifacts:
       # Persistent storage provider expected to be used for sharing persistent runtime artifacts
       # Must refer to an appropriate Kubernetes Storage Class (https://kubernetes.io/docs/concepts/storage/storage-classes/)
-      # "nfs" (default) - Using the official Kubernetes NFS Server Provisioner (https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner).
-      # This provisioner is installed by default, with this Helm Chart (wso2 -> deployment -> dependencies -> nfsServerProvisioner).
+      # "nfs" (default) - Using the official Kubernetes NFS Server Provisioner (https://github.com/helm/charts/tree/master/stable/nfs-server-provisioner)
+      # This provisioner is installed by default, with this Helm Chart (wso2 -> deployment -> dependencies -> nfsServerProvisioner)
       storageClass: "nfs"
 
     wso2is:
-
       # Hostname for Identity Server
       hostname: "identity.wso2.com"
 
       # Container image configurations
-      # If a custom image must be used, uncomment 'dockerRegistry' and provide its value.
+      # If a custom image must be used, uncomment 'dockerRegistry' and provide its value
       # dockerRegistry: ""
       imageName: "wso2is"
       imageTag: "5.10.0"
+      # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
+      imagePullPolicy: Always
 
       # Number of deployment replicas
       replicas: 2
-      strategy:
-        rollingUpdate:
-          # The maximum number of pods that can be scheduled above the desired number of pods.
-          maxSurge: 1
-          # The maximum number of pods that can be unavailable during the update.
-          maxUnavailable: 0
-      # Indicates whether the container is running.
+
+      # Indicates whether the container is running
       livenessProbe:
-        # Number of seconds after the container has started before liveness probes are initiated.
+        # Number of seconds after the container has started before liveness probes are initiated
         initialDelaySeconds: 120
-        # How often (in seconds) to perform the probe.
+        # How often (in seconds) to perform the probe
         periodSeconds: 10
-      # Indicates whether the container is ready to service requests.
+      # Indicates whether the container is ready to service requests
       readinessProbe:
-        # Number of seconds after the container has started before readiness probes are initiated.
+        # Number of seconds after the container has started before readiness probes are initiated
         initialDelaySeconds: 120
-        # How often (in seconds) to perform the probe.
+        # How often (in seconds) to perform the probe
         periodSeconds: 10
+
       resources:
         # These are the minimum resource recommendations for running WSO2 Identity and Access Management product profiles
-        # as per official documentation (https://docs.wso2.com/display/IS580/Installation+Prerequisites).
+        # as per official documentation (https://is.docs.wso2.com/en/latest/setup/installation-prerequisites/)
         requests:
           # The minimum amount of memory that should be allocated for a Pod
           memory: "2Gi"
@@ -79,9 +74,10 @@ wso2:
           memory: "4Gi"
           # The maximum amount of CPU that should be allocated for a Pod
           cpu: "4000m"
-      # Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
-      imagePullPolicy: Always
-      config: ""
+
+      # If the deployment configurations for the WSO2 Identity Server v5.10.0 (<WSO2IS>/repository/conf/deployment.toml),
+      # add the customized configuration file under (wso2 -> deployment -> wso2is -> config -> deployment.toml)
+#      config: ""
 #        deployment.toml: |-
 #          # Deployment configurations for Identity Server deployment
 #          # <replace with deployment configurations for the WSO2 Identity Server (<WSO2IS>/repository/conf/deployment.toml)>


### PR DESCRIPTION
## Purpose
> This PR performs $subject fixing https://github.com/wso2/kubernetes-is/issues/242. Furthermore, it adds the necessary configurations fixing https://github.com/wso2/kubernetes-is/issues/243.

## Goals
> Avoid Packaging the NFS Server Provisioner

## Test environment
> Helm version: 3.1.2
> GKE based Kubernetes Server version: 1.14+, Git Version: `v1.14.10-gke.27`
> WSO2 Private Docker Registry images were utilized