### PR TITLE
[v5.10.x] Allocate Memory for JVM Heap

### DIFF
--- a/advanced/is-pattern-1/README.md
+++ b/advanced/is-pattern-1/README.md
@@ -212,13 +212,17 @@ to true).
 | `wso2.deployment.wso2is.livenessProbe.periodSeconds`                        | Period of the live-ness probe for IS node                                                 | 10                          |
 | `wso2.deployment.wso2is.readinessProbe.initialDelaySeconds`                 | Initial delay for the readiness probe for IS node                                         | 120                         |
 | `wso2.deployment.wso2is.readinessProbe.periodSeconds`                       | Period of the readiness probe for IS node                                                 | 10                          |
-| `wso2.deployment.wso2is.resources.requests.memory`                          | The minimum amount of memory that should be allocated for a Pod                           | 2Gi                         |
-| `wso2.deployment.wso2is.resources.requests.cpu`                             | The minimum amount of CPU that should be allocated for a Pod                              | 2000m                       |
+| `wso2.deployment.wso2is.resources.requests.memory`                          | The minimum amount of memory that should be allocated for a Pod                           | 3Gi                         |
+| `wso2.deployment.wso2is.resources.requests.cpu`                             | The minimum amount of CPU that should be allocated for a Pod                              | 3000m                       |
 | `wso2.deployment.wso2is.resources.limits.memory`                            | The maximum amount of memory that should be allocated for a Pod                           | 4Gi                         |
 | `wso2.deployment.wso2is.resources.limits.cpu`                               | The maximum amount of CPU that should be allocated for a Pod                              | 4000m                       |
+| `wso2.deployment.wso2is.resources.jvm.heap.memory.xms`                      | The initial memory allocation for JVM Heap                                                | 2048m                       |
+| `wso2.deployment.wso2is.resources.jvm.heap.memory.xmx`                      | The maximum memory allocation for JVM Heap                                                | 2048m                       |
 | `wso2.deployment.wso2is.config`                                             | Custom deployment configuration file (`<WSO2IS>/repository/conf/deployment.toml`)         | -                           |
 
-> The above mentioned default, minimum resource amounts for running WSO2 Identity Server profiles are based on its [official documentation](https://is.docs.wso2.com/en/latest/setup/installation-prerequisites/).
+> The above referenced default, minimum resource amounts for running WSO2 Identity Server profiles are based on its [official documentation](https://is.docs.wso2.com/en/latest/setup/installation-prerequisites/).
+
+> The above referenced JVM settings are based on its [official documentation](https://is.docs.wso2.com/en/latest/setup/performance-tuning-recommendations/#jvm-settings).
 
 ###### Centralized Logging Configurations
 

--- a/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-statefulset.yaml
+++ b/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-statefulset.yaml
@@ -77,6 +77,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: JVM_MEM_OPTS
+              value: "-Xms{{ .Values.wso2.deployment.wso2is.resources.jvm.heap.memory.xms }} -Xmx{{ .Values.wso2.deployment.wso2is.resources.jvm.heap.memory.xmx }}"
           livenessProbe:
             exec:
               command:

--- a/advanced/is-pattern-1/values.yaml
+++ b/advanced/is-pattern-1/values.yaml
@@ -77,14 +77,25 @@ wso2:
         # as per official documentation (https://is.docs.wso2.com/en/latest/setup/installation-prerequisites/)
         requests:
           # The minimum amount of memory that should be allocated for a Pod
-          memory: "2Gi"
+          memory: "3Gi"
           # The minimum amount of CPU that should be allocated for a Pod
-          cpu: "2000m"
+          cpu: "3000m"
         limits:
           # The maximum amount of memory that should be allocated for a Pod
           memory: "4Gi"
           # The maximum amount of CPU that should be allocated for a Pod
           cpu: "4000m"
+        # JVM settings
+        # These are the resource allocation configurations associated with the JVM
+        # Refer to the official documentation for advanced details (https://is.docs.wso2.com/en/latest/setup/performance-tuning-recommendations/#jvm-settings)
+        jvm:
+          # Resource allocation for the Java Heap
+          heap:
+            memory:
+              # Initial and minimum Heap size
+              xms: "2048m"
+              # Maximum Heap size
+              xmx: "2048m"
 
       # If the deployment configurations for the WSO2 Identity Server v5.10.0 (<WSO2IS>/repository/conf/deployment.toml),
       # add the customized configuration file under (wso2 -> deployment -> wso2is -> config -> deployment.toml)


### PR DESCRIPTION
## Purpose
> This PR performs $subject thus fixing the linked issue.

## Goals
> Allocate memory for JVM heap

## Test environment
> Helm version: `3.2.4`
> GKE based Kubernetes Server version: `1.15`+, Git Version: `v1.15.12-gke.2`
> Product Docker images from WSO2 Private Docker Registry were used