### PR TITLE
[v5.10.x] Add Input Option to Set Ingress Class and Annotations

### DIFF
--- a/advanced/is-pattern-1/README.md
+++ b/advanced/is-pattern-1/README.md
@@ -142,7 +142,7 @@ kubectl get ing -n <NAMESPACE>
 The output under the relevant column stands for the following.
 
 - NAME: Metadata name of the Kubernetes Ingress resource (defaults to `wso2is-pattern-1-identity-server-ingress`)
-- HOSTS: Hostname of the WSO2 Identity service (`<wso2.deployment.wso2is.hostname>`)
+- HOSTS: Hostname of the WSO2 Identity service (`<wso2.deployment.wso2is.ingress.identity.hostname>`)
 - ADDRESS: External IP (`EXTERNAL-IP`) exposing the Identity service to outside of the Kubernetes environment
 - PORTS: Externally exposed service ports of the Identity service
 
@@ -155,12 +155,12 @@ If the defined hostname is not backed by a DNS service, for the purpose of evalu
 hostname and the external IP in the `/etc/hosts` file at the client-side.
 
 ```
-<EXTERNAL-IP> <wso2.deployment.wso2is.hostname>
+<EXTERNAL-IP> <wso2.deployment.wso2is.ingress.identity.hostname>
 ```
 
 ### 4. Access Management Console
 
-- Identity Server's Carbon Management Console: `https://<wso2.deployment.wso2is.hostname>/carbon`
+- Identity Server's Carbon Management Console: `https://<wso2.deployment.wso2is.ingress.identity.hostname>/carbon`
 
 ## Configuration
 
@@ -201,7 +201,6 @@ The following tables lists the configurable parameters of the chart and their de
 
 | Parameter                                                                   | Description                                                                               | Default Value               |
 |-----------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|-----------------------------|
-| `wso2.deployment.wso2is.hostname`                                           | Hostname for for IS service                                                               | `identity.wso2.com`         |
 | `wso2.deployment.wso2is.dockerRegistry`                                     | Registry location of the Docker image to be used to create Identity Server instances      | -                           |
 | `wso2.deployment.wso2is.imageName`                                          | Name of the Docker image to be used to create Identity Server instances                   | `wso2is`                    |
 | `wso2.deployment.wso2is.imageTag`                                           | Tag of the image used to create Identity Server instances                                 | `5.10.0`                    |
@@ -218,6 +217,8 @@ The following tables lists the configurable parameters of the chart and their de
 | `wso2.deployment.wso2is.resources.jvm.heap.memory.xms`                      | The initial memory allocation for JVM Heap                                                | 2048m                       |
 | `wso2.deployment.wso2is.resources.jvm.heap.memory.xmx`                      | The maximum memory allocation for JVM Heap                                                | 2048m                       |
 | `wso2.deployment.wso2is.config`                                             | Custom deployment configuration file (`<WSO2IS>/repository/conf/deployment.toml`)         | -                           |
+| `wso2.deployment.wso2is.ingress.identity.hostname`                          | Hostname for for Identity service                                                         | `identity.wso2.com`         |
+| `wso2.deployment.wso2is.ingress.identity.annotations`                       | Ingress resource annotations for Identity service                                         | Community NGINX Ingress controller annotations         |
 
 > The above referenced default, minimum resource amounts for running WSO2 Identity Server profiles are based on its [official documentation](https://is.docs.wso2.com/en/latest/setup/installation-prerequisites/).
 

--- a/advanced/is-pattern-1/templates/NOTES.txt
+++ b/advanced/is-pattern-1/templates/NOTES.txt
@@ -9,20 +9,20 @@ Please follow these steps to access the Management Console.
   The output under the relevant column stands for the following.
 
   - NAME: Metadata name of the Kubernetes Ingress resource (defaults to {{ template "is-pattern-1.resource.prefix" . }}-identity-server-ingress)
-  - HOSTS: Hostname of the WSO2 Identity service ({{ .Values.wso2.deployment.wso2is.hostname }})
+  - HOSTS: Hostname of the WSO2 Identity service ({{ .Values.wso2.deployment.wso2is.ingress.identity.hostname }})
   - ADDRESS: External IP (`EXTERNAL-IP`) exposing the Identity service to outside of the Kubernetes environment
   - PORTS: Externally exposed service ports of the Identity service
 
 2. Add a DNS record mapping the Identity service hostname and the external IP.
 
-   If the defined hostname (i.e. {{ .Values.wso2.deployment.wso2is.hostname }}) is backed by a DNS service, add a DNS record mapping the hostname and
+   If the defined hostname (i.e. {{ .Values.wso2.deployment.wso2is.ingress.identity.hostname }}) is backed by a DNS service, add a DNS record mapping the hostname and
    the external IP (`EXTERNAL-IP`) in the relevant DNS service.
 
    If the defined hostname is not backed by a DNS service, for the purpose of evaluation you may add an entry mapping the
    hostname and the external IP in the `/etc/hosts` file at the client-side.
 
-   <EXTERNAL-IP> {{ .Values.wso2.deployment.wso2is.hostname }}
+   <EXTERNAL-IP> {{ .Values.wso2.deployment.wso2is.ingress.identity.hostname }}
 
-3. Navigate to https://{{ .Values.wso2.deployment.wso2is.hostname }}/carbon in your browser of choice.
+3. Navigate to https://{{ .Values.wso2.deployment.wso2is.ingress.identity.hostname }}/carbon in your browser of choice.
 
 Please refer the official documentation at https://is.docs.wso2.com/en/latest for additional information on WSO2 Identity Server.

--- a/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-conf.yaml
+++ b/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-conf.yaml
@@ -30,7 +30,7 @@ data:
   deployment.toml: |-
     # Deployment config for Identity Server deployment
     [server]
-    hostname = "{{ .Values.wso2.deployment.wso2is.hostname }}"
+    hostname = "{{ .Values.wso2.deployment.wso2is.ingress.identity.hostname }}"
     node_ip = "$env{NODE_IP}"
 
     [super_admin]

--- a/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-ingress.yaml
+++ b/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-ingress.yaml
@@ -18,18 +18,16 @@ kind: Ingress
 metadata:
   name: {{ template "is-pattern-1.resource.prefix" . }}-identity-server-ingress
   namespace : {{ .Release.Namespace }}
+{{- if .Values.wso2.deployment.wso2is.ingress.identity.annotations }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    nginx.ingress.kubernetes.io/affinity: "cookie"
-    nginx.ingress.kubernetes.io/session-cookie-name: "route"
-    nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
+{{ toYaml .Values.wso2.deployment.wso2is.ingress.identity.annotations | indent 4 }}
+{{- end }}
 spec:
   tls:
   - hosts:
-    - {{ .Values.wso2.deployment.wso2is.hostname }}
+    - {{ .Values.wso2.deployment.wso2is.ingress.identity.hostname }}
   rules:
-  - host: {{ .Values.wso2.deployment.wso2is.hostname }}
+  - host: {{ .Values.wso2.deployment.wso2is.ingress.identity.hostname }}
     http:
       paths:
       - path: /

--- a/advanced/is-pattern-1/values.yaml
+++ b/advanced/is-pattern-1/values.yaml
@@ -45,9 +45,6 @@ wso2:
           userstores: 50M
 
     wso2is:
-      # Hostname for Identity Server
-      hostname: "identity.wso2.com"
-
       # Container image configurations
       # If a custom image must be used, uncomment 'dockerRegistry' and provide its value
       # dockerRegistry: ""
@@ -103,6 +100,19 @@ wso2:
 #        deployment.toml: |-
 #          # Deployment configurations for Identity Server deployment
 #          # <replace with deployment configurations for the WSO2 Identity Server (<WSO2IS>/repository/conf/deployment.toml)>
+
+      # Configure Ingresses
+      ingress:
+        identity:
+          # Hostname for Identity Server
+          hostname: "identity.wso2.com"
+          # Annotations for the Identity service Ingress
+          annotations:
+            kubernetes.io/ingress.class: "nginx"
+            nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+            nginx.ingress.kubernetes.io/affinity: "cookie"
+            nginx.ingress.kubernetes.io/session-cookie-name: "route"
+            nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
 
   # Configurations for the logstash container image and elasticsearch authorization credentials
   # Centralized logging is disabled by default. If it is required to enable centralized logging, please follow the instructions


### PR DESCRIPTION
## Purpose
> This PR performs $subject, thus closing the linked issue.

## Goals
> Add input option to set Ingress class and annotations

## Test environment
> Helm version: `3.2.4`
> GKE based Kubernetes Server version: `1.15`+, Git Version: `v1.15.12-gke.2`
> Product Docker images from WSO2 organization in DockerHub