### PR TITLE
[v5.10.x] Upgrade Base Stable MySQL Helm Chart - 2020-08-21

### DIFF
--- a/advanced/databases/mysql-is/requirements.yaml
+++ b/advanced/databases/mysql-is/requirements.yaml
@@ -13,5 +13,5 @@
 # limitations under the License.
 dependencies:
   - name: mysql
-    version: "1.6.3"
+    version: "1.6.6"
     repository: "https://kubernetes-charts.storage.googleapis.com"


### PR DESCRIPTION
## Purpose
> This PR fixes $subject, thus closing the linked issue.

## Goals
> Upgrade Base Stable MySQL Helm Chart - 2020-08-21

## Test environment
> Helm version: `3.2.4`
> GKE based Kubernetes Server version: `1.15`+, Git Version: `v1.15.12-gke.2`
> Product Docker images from WSO2 organization in DockerHub