### PR TITLE
Add secretName to spec.tls. Closes #294

### DIFF
--- a/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-ingress.yaml
+++ b/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-ingress.yaml
@@ -26,6 +26,7 @@ spec:
   tls:
   - hosts:
     - {{ .Values.wso2.deployment.wso2is.ingress.identity.hostname }}
+    secretName: {{ template "is-pattern-1.resource.prefix" . }}-tls
   rules:
   - host: {{ .Values.wso2.deployment.wso2is.ingress.identity.hostname }}
     http:


### PR DESCRIPTION
## Purpose
Be able to configure a TLS certificate secret in your k8s cluster, based on the wso2is deployment name

## Goals
Added secretName to spec.tls property in the ingress config file


## User stories
#294 

## Release note
Added secretName to spec.tls property in the ingress config file, so that you can add a TLS certificate secret to your k8s cluster that will be used for requests to wso2is.

## Documentation
N/A. Nothing changes in regards to what the user has to configure

## Certification
N/A. This is a very basic kubernetes feature.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
This allows you to do this:
```
sudo kubectl create secret tls wso2is-pattern-1-tls -n <NAMESPACE> --cert="path/to/cert.pem" --key="path/to/key.pem"
```

## Test environment
OS: Windows 10 2020H2 using WSL2 Ubuntu 18.04
K8S: v1.18
kubernetes-is: 5.11.0-3
