### PR TITLE
remove sed for base64 encoded strings. improve script resilience

### DIFF
--- a/advanced/is-pattern-1/README.md
+++ b/advanced/is-pattern-1/README.md
@@ -34,6 +34,8 @@ For advanced details on the deployment pattern, please refer the official
 
 * An already setup [Kubernetes cluster](https://kubernetes.io/docs/setup).<br><br>
 
+* Ensure Kubernetes cluster has enough resources
+
 * Install [NGINX Ingress Controller](https://kubernetes.github.io/ingress-nginx/deploy/).<br><br>
 
 * Add the WSO2 Helm chart repository.
@@ -46,13 +48,13 @@ For advanced details on the deployment pattern, please refer the official
 
 ### 1. Install the Helm Chart
 
-You can install the relevant Helm chart either from [WSO2 Helm Chart Repository](https://hub.helm.sh/charts/wso2) or by source.
+You can install the relevant Helm chart either from [WSO2 Helm Chart Repository](https://artifacthub.io/packages/search?page=1&repo=wso2) or by source.
 
 **Note:**
 
 * `NAMESPACE` should be the Kubernetes Namespace in which the resources are deployed.
 
-#### Install Chart From [WSO2 Helm Chart Repository](https://hub.helm.sh/charts/wso2)
+#### Install Chart From [WSO2 Helm Chart Repository](https://artifacthub.io/packages/search?page=1&repo=wso2)
 
  **Helm version 2**
 
@@ -81,8 +83,16 @@ please provide your WSO2 Subscription Credentials via input values (using `--set
 
 Refer the following example.
 
+ **Helm version 2**
+
 ```
  helm install --name <RELEASE_NAME> wso2/is-pattern-1 --version 5.11.0-3 --namespace <NAMESPACE> --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
+```
+
+ **Helm version 3**
+
+```
+ helm install <RELEASE_NAME> wso2/is-pattern-1 --version 5.11.0-3 --namespace <NAMESPACE> --set wso2.subscription.username=<SUBSCRIPTION_USERNAME> --set wso2.subscription.password=<SUBSCRIPTION_PASSWORD>
 ```
 
 #### Install Chart From Source

--- a/simple/README.md
+++ b/simple/README.md
@@ -14,6 +14,8 @@
 
 * An already setup [Kubernetes cluster](https://kubernetes.io/docs/setup).
 
+* Ensure Kubernetes cluster has enough resources
+
 * WSO2 product Docker images used for the Kubernetes deployment.
   
   WSO2 product Docker images available at [DockerHub](https://hub.docker.com/u/wso2/) package General Availability (GA)

--- a/simple/create.sh
+++ b/simple/create.sh
@@ -34,20 +34,19 @@ cat >> $SCRIPT << "EOF"
 k8s_obj_file="deployment.yaml"; NODE_IP=''; str_sec=""
 license_text="LICENSE.txt"
 
-# wso2 subscription variables
-WUMUsername=''; WUMPassword=''
+# wso2 image variables
 EOF
 
 if $IS_OPEN_SOURCE; then
   echo 'IMG_DEST="wso2"' >> $SCRIPT
+  echo 'IMG_TAG="5.11.0"' >> $SCRIPT
 else
   echo 'IMG_DEST="docker.wso2.com"' >> $SCRIPT
+  echo 'IMG_TAG="5.11.0.0"' >> $SCRIPT
 fi
 
 cat >> $SCRIPT << "EOF"
 
-# wso2 subscription variables
-WUMUsername=''; WUMPassword=''
 
 : ${NP_1:=30443};
 

--- a/simple/deployment-scripts/wso2is-ga.sh
+++ b/simple/deployment-scripts/wso2is-ga.sh
@@ -21,12 +21,10 @@ set -e
 k8s_obj_file="deployment.yaml"; NODE_IP=''; str_sec=""
 license_text="LICENSE.txt"
 
-# wso2 subscription variables
-WUMUsername=''; WUMPassword=''
+# wso2 image variables
 IMG_DEST="wso2"
+IMG_TAG="5.11.0"
 
-# wso2 subscription variables
-WUMUsername=''; WUMPassword=''
 
 : ${NP_1:=30443};
 
@@ -1998,7 +1996,7 @@ spec:
             mountPath: /mysql-connector-jar
       containers:
       - name: wso2is
-        image: "$image.pull.@.wso2"/wso2is:5.11.0
+        image: "$image.pull.@.wso2"/wso2is:"$image.tag.wso2is"
         livenessProbe:
           exec:
             command:
@@ -2272,11 +2270,10 @@ function deploy(){
     create_yaml
 
     # replace placeholders
-    sed -i.bak 's/"$string.&.secret.auth.data"/'$secdata'/g' $k8s_obj_file
-    sed -i.bak 's/"$nodeport.k8s.&.1.wso2is"/'$NP_1'/g' $k8s_obj_file
+    sed -i.bak 's|"$nodeport.k8s.&.1.wso2is"|'$NP_1'|g' $k8s_obj_file
     sed -i.bak 's|"$image.pull.@.wso2"|'$IMG_DEST'|g' $k8s_obj_file
-
-    rm deployment.yaml.bak
+    sed -i.bak 's|"$image.tag.wso2is"|'$IMG_TAG'|g' $k8s_obj_file
+    rm "$k8s_obj_file.bak"
 
     echoBold "\nDeploying WSO2 Identity Server...\n"
 

--- a/simple/funcs
+++ b/simple/funcs
@@ -264,29 +264,21 @@ function deploy(){
     # getting cluster node ip
     get_node_ip
 
-    # create and encode username/password pair
-    auth="$WSO2_SUBSCRIPTION_USERNAME:$WSO2_SUBSCRIPTION_PASSWORD"
-    authb64=`echo -n $auth | base64`
-
-    # create authorisation code
-    authstring='{"auths":{"docker.wso2.com": {"username":"'${WSO2_SUBSCRIPTION_USERNAME}'","password":"'${WSO2_SUBSCRIPTION_PASSWORD}'","email":"'${WSO2_SUBSCRIPTION_USERNAME}'","auth":"'${authb64}'"}}}'
-
-    # encode in base64
-    secdata=`echo -n $authstring | base64`
-
-    for i in $secdata; do
-      str_sec=$str_sec$i
-    done
+    # create and encode username/password secret
+    kubectl delete secret wso2-reg-creds --ignore-not-found=true
+    kubectl create secret docker-registry wso2-reg-creds --docker-server="docker.wso2.com" --docker-username="$WSO2_SUBSCRIPTION_USERNAME" --docker-password="$WSO2_SUBSCRIPTION_PASSWORD" --docker-email="$WSO2_SUBSCRIPTION_USERNAME"
+    str_sec=`kubectl get secret wso2-reg-creds --output="jsonpath={.data.\.dockerconfigjson}"`;
+    kubectl delete secret wso2-reg-creds;
 
     #create kubernetes object yaml
     create_yaml
 
     # replace placeholders
-    sed -i.bak 's/"$string.&.secret.auth.data"/'$str_sec'/g' $k8s_obj_file
-    sed -i.bak 's/"$nodeport.k8s.&.1.wso2is"/'$NP_1'/g' $k8s_obj_file
+    sed -i.bak 's|"$string.&.secret.auth.data"|'$str_sec'|g' $k8s_obj_file
+    sed -i.bak 's|"$nodeport.k8s.&.1.wso2is"|'$NP_1'|g' $k8s_obj_file
     sed -i.bak 's|"$image.pull.@.wso2"|'$IMG_DEST'|g' $k8s_obj_file
-
-    rm deployment.yaml.bak
+    sed -i.bak 's|"$image.tag.wso2is"|'$IMG_TAG'|g' $k8s_obj_file
+    rm "$k8s_obj_file.bak"
 
     echoBold "\nDeploying WSO2 Identity Server...\n"
 

--- a/simple/funcs4opensource
+++ b/simple/funcs4opensource
@@ -211,11 +211,10 @@ function deploy(){
     create_yaml
 
     # replace placeholders
-    sed -i.bak 's/"$string.&.secret.auth.data"/'$secdata'/g' $k8s_obj_file
-    sed -i.bak 's/"$nodeport.k8s.&.1.wso2is"/'$NP_1'/g' $k8s_obj_file
+    sed -i.bak 's|"$nodeport.k8s.&.1.wso2is"|'$NP_1'|g' $k8s_obj_file
     sed -i.bak 's|"$image.pull.@.wso2"|'$IMG_DEST'|g' $k8s_obj_file
-
-    rm deployment.yaml.bak
+    sed -i.bak 's|"$image.tag.wso2is"|'$IMG_TAG'|g' $k8s_obj_file
+    rm "$k8s_obj_file.bak"
 
     echoBold "\nDeploying WSO2 Identity Server...\n"
 

--- a/simple/is-k8s/identity-server-deployment.yaml
+++ b/simple/is-k8s/identity-server-deployment.yaml
@@ -48,7 +48,7 @@ spec:
             mountPath: /mysql-connector-jar
       containers:
       - name: wso2is
-        image: "$image.pull.@.wso2"/wso2is:5.11.0
+        image: "$image.pull.@.wso2"/wso2is:"$image.tag.wso2is"
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
Purpose
This will prevent special characters in the base64 encoded output to affect the sed command by removing in favor of using the kubctl CLI tool to generate the secret. Additionally, if the k8s file name variable was updated it would break on the removal of the .bak file. As well as the docker image tag structure has diverted from GA and subscription images. Introduced a variable to allow for each script to declare which version of the image to use.

Goals
make the script more resilient

Samples
my subscription password has special chars (?$) which resulted in a (/) in the base64 encoding. 