### PR TITLE
Update base_path to the server hostname

### DIFF
--- a/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-conf.yaml
+++ b/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-conf.yaml
@@ -32,7 +32,7 @@ data:
     [server]
     hostname = "{{ .Values.wso2.deployment.wso2is.ingress.identity.hostname }}"
     node_ip = "$env{NODE_IP}"
-    base_path = "https://$ref{server.hostname}:${carbon.management.port}"
+    base_path = "https://$ref{server.hostname}"
 
     [super_admin]
     username = "admin"


### PR DESCRIPTION

## Purpose
> nginx is proxying the https id_token auth and needs to omit the port for endpoint URLs

## Related Issues
> User reported [issue](https://github.com/wso2/product-is/issues/10645) 
