### PR TITLE
Align name of MySQL dependency condition key

### DIFF
--- a/advanced/is-pattern-1/requirements.yaml
+++ b/advanced/is-pattern-1/requirements.yaml
@@ -15,4 +15,4 @@ dependencies:
   - name: mysql-is
     version: "5.11.0-3"
     repository: "https://helm.wso2.com"
-    condition: wso2.mysql.enabled
+    condition: wso2.deployment.dependencies.mysql.enabled

--- a/advanced/is-pattern-1/values.yaml
+++ b/advanced/is-pattern-1/values.yaml
@@ -22,8 +22,9 @@ wso2:
 
   deployment:
     dependencies:
-      # The configuration should be set to be 'true' if a MySQL database should be spawned as a pod within the cluster
-      mysql: true
+      mysql:
+        # The configuration should be set to be 'true' if a MySQL database should be spawned as a pod within the cluster
+        enabled: true
 
     # Persisted and shared runtime artifacts for Identity Server
     # See official documentation (from https://is.docs.wso2.com/en/latest/setup/deployment-guide/#enabling-artifact-synchronization)


### PR DESCRIPTION
## Purpose
Resolves a triple mismatch for the key name of the MySQL deployment setting. [Documentation](https://github.com/wso2/kubernetes-is/blob/e84936f53afe03fc54b8bad554a5dbdd2c8687b1/advanced/is-pattern-1/README.md#chart-dependencies), [`values.yaml`](https://github.com/wso2/kubernetes-is/blob/e84936f53afe03fc54b8bad554a5dbdd2c8687b1/advanced/is-pattern-1/values.yaml#L26) and [`requirements.yaml`](https://github.com/wso2/kubernetes-is/blob/e84936f53afe03fc54b8bad554a5dbdd2c8687b1/advanced/is-pattern-1/requirements.yaml#L18) all had different settings. These were, respectively, `wso2.deployment.dependencies.mysql.enabled`, `wso2.deployment.dependencies.mysql`, and `wso2.mysql.enabled`. 

This PR aligns all of these to use the key from the documentation, namely **`wso2.deployment.dependencies.mysql.enabled`**. This is the [form preferred by Helm for conditions](https://helm.sh/docs/chart_best_practices/dependencies/#conditions-and-tags). 
