### PR TITLE
Evaluate Startup Probe for WSO2 Identity Server Workload

### DIFF
--- a/advanced/databases/mysql-is/Chart.yaml
+++ b/advanced/databases/mysql-is/Chart.yaml
@@ -15,5 +15,5 @@ apiVersion: v1
 appVersion: "5.7"
 description: A Helm chart for MySQL based deployment of WSO2 Identity And Access Management Datasources
 name: mysql-is
-version: 5.11.0-3
+version: 5.11.0-5
 icon: https://wso2.cachefly.net/wso2/sites/all/images/wso2logo.svg

--- a/advanced/is-pattern-1/Chart.yaml
+++ b/advanced/is-pattern-1/Chart.yaml
@@ -16,5 +16,5 @@ apiVersion: v1
 appVersion: "5.11.0"
 description: A Helm chart for the deployment of WSO2 Identity And Access Management pattern 1
 name: is-pattern-1
-version: 5.11.0-4
+version: 5.11.0-5
 icon: https://wso2.cachefly.net/wso2/sites/all/images/wso2logo.svg

--- a/advanced/is-pattern-1/requirements.yaml
+++ b/advanced/is-pattern-1/requirements.yaml
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 dependencies:
   - name: mysql-is
-    version: "5.11.0-3"
+    version: "5.11.0-5"
     repository: "https://helm.wso2.com"
     condition: wso2.deployment.dependencies.mysql.enabled

--- a/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-statefulset.yaml
+++ b/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-statefulset.yaml
@@ -83,13 +83,21 @@ spec:
                   fieldPath: status.podIP
             - name: JVM_MEM_OPTS
               value: "-Xms{{ .Values.wso2.deployment.wso2is.resources.jvm.heap.memory.xms }} -Xmx{{ .Values.wso2.deployment.wso2is.resources.jvm.heap.memory.xmx }}"
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - nc -z localhost 9443
+            initialDelaySeconds: {{ .Values.wso2.deployment.wso2is.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.wso2.deployment.wso2is.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.wso2.deployment.wso2is.startupProbe.failureThreshold }}
           livenessProbe:
             exec:
               command:
                 - /bin/sh
                 - -c
                 - nc -z localhost 9443
-            initialDelaySeconds: {{ .Values.wso2.deployment.wso2is.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.wso2.deployment.wso2is.livenessProbe.periodSeconds }}
           readinessProbe:
             exec:

--- a/advanced/is-pattern-1/values.yaml
+++ b/advanced/is-pattern-1/values.yaml
@@ -57,16 +57,23 @@ wso2:
       # Number of deployment replicas
       replicas: 2
 
+      # Kubernetes Probes
+      # Startup probe executed prior to Liveness Probe taking over
+      startupProbe:
+        # Number of seconds after the container has started before startup probes are initiated
+        initialDelaySeconds: 60
+        # How often (in seconds) to perform the probe
+        periodSeconds: 5
+        # Number of attempts
+        failureThreshold: 30
       # Indicates whether the container is running
       livenessProbe:
-        # Number of seconds after the container has started before liveness probes are initiated
-        initialDelaySeconds: 120
         # How often (in seconds) to perform the probe
         periodSeconds: 10
       # Indicates whether the container is ready to service requests
       readinessProbe:
         # Number of seconds after the container has started before readiness probes are initiated
-        initialDelaySeconds: 120
+        initialDelaySeconds: 60
         # How often (in seconds) to perform the probe
         periodSeconds: 10
 


### PR DESCRIPTION
## Purpose
> This performs $subject and adds a Kubernetes startup probe fixing https://github.com/wso2/kubernetes-is/issues/230.

## Goals
> Add Kubernetes startup probe to address Identity Server startup


## Test environment
> Client Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.22.3"}
> Server Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.22.1"}