### PR TITLE
Use WSO2 Identity Server Health Check API for Kubernetes Readiness Probe

### DIFF
--- a/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-conf.yaml
+++ b/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-conf.yaml
@@ -119,6 +119,11 @@ data:
     properties.KUBERNETES_MASTER_SKIP_SSL_VERIFICATION = "true"
     properties.USE_DNS = "false"
 
+    [carbon_health_check]
+    enable= true
+    health_checker.super_tenant_health_checker.properties.'monitored.user.stores' = "primary"
+    health_checker.data_source_health_checker.properties.'monitored.datasources' = "jdbc/WSO2CarbonDB,jdbc/WSO2USER_DB,jdbc/SHARED_DB,jdbc/WSO2ConsentDS,jdbc/WSO2IdentityDB"
+
     {{ if .Values.wso2.monitoring.enabled }}
     [monitoring.jmx]
     rmi_server_start = true

--- a/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-statefulset.yaml
+++ b/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-statefulset.yaml
@@ -93,18 +93,16 @@ spec:
             periodSeconds: {{ .Values.wso2.deployment.wso2is.startupProbe.periodSeconds }}
             failureThreshold: {{ .Values.wso2.deployment.wso2is.startupProbe.failureThreshold }}
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - nc -z localhost 9443
+            httpGet:
+              path: /carbon/admin/login.jsp
+              port: 9443
+              scheme: HTTPS
             periodSeconds: {{ .Values.wso2.deployment.wso2is.livenessProbe.periodSeconds }}
           readinessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - nc -z localhost 9443
+            httpGet:
+              path: /api/health-check/v1.0/health
+              port: 9443
+              scheme: HTTPS
             initialDelaySeconds: {{ .Values.wso2.deployment.wso2is.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.wso2.deployment.wso2is.readinessProbe.periodSeconds }}
           lifecycle:


### PR DESCRIPTION
## Purpose
> This performs $subject fixing https://github.com/wso2/kubernetes-is/issues/252.

## Goals
> Use WSO2 Identity Server Health Check API for Kubernetes Readiness Probe

## Test environment
> Client Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.22.3"}
> Server Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.22.1"}