### PR TITLE
Upgrade hazelcast with member auto discovery

### DIFF
--- a/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-conf.yaml
+++ b/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-conf.yaml
@@ -113,11 +113,8 @@ data:
     [clustering]
     membership_scheme = "kubernetes"
     domain = "wso2.carbon.domain"
-    properties.membershipSchemeClassName = "org.wso2.carbon.membership.scheme.kubernetes.KubernetesMembershipScheme"
     properties.KUBERNETES_NAMESPACE = "{{ .Release.Namespace }}"
     properties.KUBERNETES_SERVICES = "{{ template "is-pattern-1.resource.prefix" . }}-identity-service"
-    properties.KUBERNETES_MASTER_SKIP_SSL_VERIFICATION = "true"
-    properties.USE_DNS = "false"
 
     [carbon_health_check]
     enable= true


### PR DESCRIPTION
## Purpose

From WSO2 IS 6.0.0-m3 , the Hazelcast members in Kubernetes deployments are discovered by the auto discovery plugin supported by Hazelcast itself. The previous custom implementation and its configurations can be decommissioned. The minimum configs for the auto discovery is provided and to enable additional configurations follow this documentation.
https://github.com/hazelcast/hazelcast-kubernetes.

### Related Issues
- https://github.com/wso2/product-is/issues/13647