### PR TITLE
Fix server startup issue in the cluster

### DIFF
--- a/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-bin.yaml
+++ b/advanced/is-pattern-1/templates/is/wso2is-pattern-1-identity-server-bin.yaml
@@ -341,6 +341,8 @@ data:
         -Dcom.sun.jndi.ldap.connect.pool.authentication=simple  \
         -Dcom.sun.jndi.ldap.connect.pool.timeout=3000  \
         -Dorg.terracotta.quartz.skipUpdateCheck=true \
+        -Djdk.util.zip.disableZip64ExtraFieldValidation=true \
+        -Djdk.nio.zipfs.allowDotZipEntry=true \
         -Djava.security.egd=file:/dev/./urandom \
         -Dfile.encoding=UTF8 \
         -Djava.net.preferIPv4Stack=true \


### PR DESCRIPTION
## Purpose

Following error was thrown during server startup in the cluster due to incompatibility issues in the latest JDK 11. 
```
 ERROR {Events.Framework} - FrameworkEvent ERROR org.osgi.framework.BundleException: Could not resolve module: org.wso2.carbon.identity.application.authenticator.fido [266]
  Unresolved requirement: Import-Package: org.wso2.carbon.identity.application.authenticator.fido2.core; version="5.3.30.1"
    -> Export-Package: org.wso2.carbon.identity.application.authenticator.fido2.core; bundle-symbolic-name="org.wso2.carbon.identity.application.authenticator.fido2"; bundle-version="5.3.30.2"; version="5.3.30.2"; uses:="com.fasterxml.jackson.core,org.wso2.carbon.identity.application.authentication.framework.exception,org.wso2.carbon.identity.application.authentication.framework.model,org.wso2.carbon.identity.application.authenticator.fido2.dto,org.wso2.carbon.identity.application.authenticator.fido2.exception,org.wso2.carbon.identity.application.authenticator.fido2.util"
       org.wso2.carbon.identity.application.authenticator.fido2 [267]
         Unresolved requirement: Import-Package: com.webauthn4j; version="0.19.1.wso2v2"

	at org.eclipse.osgi.container.Module.start(Module.java:457)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel$1.run(ModuleContainer.java:1820)
	at org.eclipse.osgi.internal.framework.EquinoxContainerAdaptor$2$1.execute(EquinoxContainerAdaptor.java:150)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.incStartLevel(ModuleContainer.java:1813)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.incStartLevel(ModuleContainer.java:1770)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.doContainerStartLevel(ModuleContainer.java:1735)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.dispatchEvent(ModuleContainer.java:1661)
	at org.eclipse.osgi.container.ModuleContainer$ContainerStartLevel.dispatchEvent(ModuleContainer.java:1)
	at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:234)
	at org.eclipse.osgi.framework.eventmgr.EventManager$EventThread.run(EventManager.java:345)
```

This PR fixes this issue

### Related issue
- https://github.com/wso2/product-is/issues/19634