### PR TITLE
If-Condition to disable AppArmor

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ User or service principle who installs the Helm chart, needs to possess actions 
 ### Prerequisites
 * Kubernetes ingress controller. Default integration is [Kubernetes Nginx ingress controller](https://github.com/kubernetes/ingress-nginx).
 * An active [WSO2 Subscription](https://wso2.com/subscription).
+* AppArmor Security Module
 ---
 
 1. Add the WSO2 Helm chart repository.
@@ -62,6 +63,8 @@ kubectl get namespace ${NAMESPACE} || kubectl create namespace ${NAMESPACE}
  --set wso2.subscription.username="$WSO2_USERNAME" \
  --set wso2.subscription.password="$WSO2_PASSWORD"
 ```
+
+**Note:** To disable AppArmor, set `--set deployment.apparmor.enabled="false"` (default: true)  
 
 #### Install Chart From Source
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -42,7 +42,9 @@ spec:
         checksum.log4j.properties: {{ include (print $.Template.BasePath "/cm-log4j2-properties.yaml") . | sha256sum }}
         checksum.entrypoint.sh: {{ include (print $.Template.BasePath "/cm-entrypoint.yaml") . | sha256sum }}
         checksum.thrift-authentication.xml: {{ include (print $.Template.BasePath "/cm-thrift-authentication-xml.yaml") . | sha256sum }}
+        {{- if .Values.deployment.apparmor.enabled }}
         container.apparmor.security.beta.kubernetes.io/wso2is: {{ .Values.deployment.apparmor.profile }}
+        {{- end }}
     spec:
       securityContext:
         runAsUser: {{ .Values.deployment.securityContext.runAsUser }}

--- a/values.yaml
+++ b/values.yaml
@@ -23,6 +23,8 @@ wso2:
 
 deployment:
   apparmor:
+    # -- Flag to enable Apparmor
+    enabled: true
     # -- Apparmor profile
     profile: "runtime/default"
   ingress:


### PR DESCRIPTION
## Purpose  
Enable AppArmor by default and provide the option to disable it through an if-condition.

## Goals  
- Implemented an if-condition to allow AppArmor to be disabled when needed.
- Added a note in the README to inform users about the AppArmor configuration and how to disable it.  
- Ensures that AppArmor is enabled by default, preventing unnecessary restrictions on containers unless explicitly enabled.  