### PR TITLE
Add support for proxyPort configuration

### DIFF
--- a/confs/deployment.toml
+++ b/confs/deployment.toml
@@ -21,7 +21,7 @@ base_path = "https://$ref{server.hostname}:${carbon.management.port}"
 offset = {{ .Values.deploymentToml.server.offset | quote }}
 
 [transport.https.properties]
-proxyPort = 443
+proxyPort = {{ .Values.deploymentToml.transport.https.properties.proxyPort }}
 server = {{ .Values.deploymentToml.transport.https.properties.server | quote }}
 
 [transport.https.sslHostConfig.properties]

--- a/values.yaml
+++ b/values.yaml
@@ -367,6 +367,7 @@ deploymentToml:
       properties:
         # -- Server name in HTTP response headers. Ref: https://is.docs.wso2.com/en/latest/deploy/security/configure-transport-level-security/#change-the-server-name-in-http-response-headers
         server: "WSO2 Carbon Server"
+        proxyPort: 443
       sslHostConfig:
         properties:
           # -- Enabling SSL protocols in the HTTPS transport. Ref: https://is.docs.wso2.com/en/latest/deploy/security/configure-transport-level-security/#enabling-ssl-protocols-in-the-wso2-is


### PR DESCRIPTION
## Purpose
Add support for proxyPort configuration through the values.yaml
This will facilitate users to easily customize the proxy port during helm installation

A requirement to customize the proxy port arises when installing the helm chart in Rancher K3s. 

## Issue

- https://github.com/wso2/product-is/issues/23152