### PR TITLE
Make Helm chart compatible with WSO2 Identity Server 7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,21 @@
 # Changelog
 
-All notable changes to Kubernetes and Helm resources for WSO2 IAM version `7.0.x` in each resource release, will be documented in this file.
+All notable changes to Kubernetes and Helm resources for WSO2 IAM version 7.x will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [v7.0.0-1] - 2024-03-12
+---
+
+## [v7.1.0-1] - 2025-04-07
 
 ### Added
 
-- Introduce Helm resources for WSO2 Identity Server version `7.0.0`.
+- Support for **WSO2 Identity Server 7.1.0** in Helm charts.
+- `user_self_registration.callback_url` configuration in `deployment.toml` to enable self-registration use cases.
+- Documentation improvements in the README for easier setup and deployment.
+
+### Changed
+
+- Updated keystore files to use `.p12` format for internal, primary, TLS, and truststore files.
+- Made external keystore configuration **mandatory**, improving security and enabling B2B use cases.
+- Updated Docker image tags and build version to align with WSO2 IS 7.1.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updated keystore files to use `.p12` format for internal, primary, TLS, and truststore files.
 - Made external keystore configuration **mandatory**, improving security and enabling B2B use cases.
 - Updated Docker image tags and build version to align with WSO2 IS 7.1.0.
+
+## [v7.0.0-2] - 2025-02-27
+
+### Added
+
+- Add IF Condition to disable AppArmor
+- Add support for proxyPort configuration
+
+## [v7.0.0-1] - 2024-03-12
+
+### Added
+
+- Introduce Helm resources for WSO2 Identity Server version `7.0.0`.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -18,5 +18,5 @@ apiVersion: v2
 name: identity-server
 description: A Helm chart for WSO2 Identity server
 type: application
-version: 7.0.0-1
-appVersion: "7.0.0"
+version: 7.1.0-1
+appVersion: "7.1.0"

--- a/README.md
+++ b/README.md
@@ -316,16 +316,16 @@ kubectl create secret generic azure-storage-csi \
  
 - Add `internal.p12` keystore password as the secret with the name `INTERNAL-KEYSTORE-PASSWORD-DECRYPTED`. 
 
+- Replace: 
+    - `<AZURE_KEY_VAULT_NAME>` with Azure Key vault name 
+    - `<AZURE_SUBSCRIPTION_ID>` with Azure subscription ID 
+    - `<INTERNAL_KEYSTORE_PASSWORD_DECRYPTED>` with internal keystore (`internal.p12`) password.
+    
     ```shell
     export AZURE_KEY_VAULT_NAME='<AZURE_KEY_VAULT_NAME>'
     export AZURE_SUBSCRIPTION_ID='<AZURE_SUBSCRIPTION_ID>'
     export INTERNAL_KEYSTORE_PASSWORD_DECRYPTED='<INTERNAL_KEYSTORE_PASSWORD_DECRYPTED>'
     ```
-
-- Replace: 
-    - `<AZURE_KEY_VAULT_NAME>` with Azure Key vault name 
-    - `<AZURE_SUBSCRIPTION_ID>` with Azure subscription ID 
-    - `<INTERNAL_KEYSTORE_PASSWORD_DECRYPTED>` with internal keystore (`internal.p12`) password.
 
 ```shell
 az login
@@ -335,14 +335,14 @@ az keyvault secret set --vault-name "${AZURE_KEY_VAULT_NAME}" --name "INTERNAL-K
 
 - Create a Kubernetes secret to hold service principal credentials to access keyvault for [secrets-store-csi-driver-provider-azure](https://azure.github.io/secrets-store-csi-driver-provider-azure/docs/configurations/identity-access-modes/service-principal-mode/). 
 
+- Replace: 
+    - `<AZURE_KEY_VAULT_SP_APP_ID>` with Azure active directory service principle application ID 
+    - `<AZURE_KEY_VAULT_SP_APP_SECRET>` with Azure active directory service principle application secret
+    
     ```shell
     export AZURE_KEY_VAULT_SP_APP_ID='<AZURE_KEY_VAULT_SP_APP_ID>'
     export AZURE_KEY_VAULT_SP_APP_SECRET='<AZURE_KEY_VAULT_SP_APP_SECRET>'
     ```
-- Replace: 
-    - `<AZURE_KEY_VAULT_SP_APP_ID>` with Azure active directory service principle application ID 
-    - `<AZURE_KEY_VAULT_SP_APP_SECRET>` with Azure active directory service principle application secret
-
 
 ```shell
 kubectl create secret generic azure-kv-secret-store-sp \

--- a/README.md
+++ b/README.md
@@ -288,10 +288,10 @@ kubectl create secret generic keystores \
 ```
 
 **Note:**
+- Make sure to import the public key certificates of all three keystores into the truststore (client-truststore.p12).
+- Ensure that the tls.p12 used here matches the one used for creating the **is-tls** TLS kubernetes secret above.
 - To create these keystores and truststores, refer to the official guide:  
 👉 [How to Create New Keystores](https://is.docs.wso2.com/en/latest/deploy/security/keystores/create-new-keystores/)
-
-- Make sure to import the public key certificate into the truststore (client-truststore.p12).
 
 
 ## 5. Create Azure storage account secret

--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ kubectl create secret generic keystores \
 ```
 
 **Note:**
+- Make sure to import the public key certificates of all three keystores into the truststore (client-truststore.p12).
+- Ensure that the tls.p12 used here matches the one used for creating the **is-tls** TLS kubernetes secret above.
 - To create these keystores and truststores, refer to the official guide:  
 👉 [How to Create New Keystores](https://is.docs.wso2.com/en/latest/deploy/security/keystores/create-new-keystores/)
-
-- Make sure to import the public key certificate into the truststore (client-truststore.p12).
 
 
 ## 5. Install the Helm chart
@@ -160,19 +160,19 @@ If you prefer to build the chart from the source, follow the steps below:
         --set deployment.image.digest=<digest> 
         ```
 
-    ### (Optional) Override Keystore Passwords
+### (Optional) Override Keystore Passwords
 
-    If you used a custom password for keystores (instead of `wso2carbon`), provide it using these flags:
+If you used a custom password for keystores (instead of `wso2carbon`), provide it using these flags:
 
-    ```bash
-    --set deploymentToml.keystore.internal.password="<value>" \
-    --set deploymentToml.keystore.internal.keyPassword="<value>" \
-    --set deploymentToml.keystore.primary.password="<value>" \
-    --set deploymentToml.keystore.primary.keyPassword="<value>" \
-    --set deploymentToml.keystore.tls.password="<value>" \
-    --set deploymentToml.keystore.tls.keyPassword="<value>" \
-    --set deploymentToml.truststore.password="<value>"
-    ```
+```bash
+--set deploymentToml.keystore.internal.password="<value>" \
+--set deploymentToml.keystore.internal.keyPassword="<value>" \
+--set deploymentToml.keystore.primary.password="<value>" \
+--set deploymentToml.keystore.primary.keyPassword="<value>" \
+--set deploymentToml.keystore.tls.password="<value>" \
+--set deploymentToml.keystore.tls.keyPassword="<value>" \
+--set deploymentToml.truststore.password="<value>"
+```
 
 ## 6. Obtain the External IP
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WSO2 Identity Server
 
 A Helm chart for WSO2 Identity server. This Helm chart can be used to deploy highly available and scalable WSO2 identity server deployment.
-___
+
 From this Helm chart, WSO2 Identity server pods are deployed and exposed through Kubernetes ingress resource. Also in advanced setup, you can configure, Kubernetes persistence volume for sharing runtime artifacts, Kubernetes secret provider class for securing secrets, Kubernetes horizontal pod autoscaling(HPA) and Kubernetes pod disruption budget(PDB). Additionally, pod affinity is configured to increase the high availability. 
 
 ![](images/architecture.png)
@@ -25,20 +25,20 @@ User or service principle who installs the Helm chart, needs to possess actions 
 | Service                 | v1                               |
 | ServiceAccount          | v1                               |
 | Secret                  | v1                               |
+___
 
+# Quick Start Guide
 
-## Quick Start Guide
+## Prerequisites
 
-### Prerequisites
-
-#### Infrastructure
+### Infrastructure
 - Running Kubernetes cluster ([minikube](https://kubernetes.io/docs/tasks/tools/#minikube) or an alternative cluster)
 - Kubernetes ingress controller ([NGINX Ingress](https://github.com/kubernetes/ingress-nginx) recommended)
 
-#### Security
+### Security
 - AppArmor Security Module enabled
 
-#### Tools
+### Tools
 | Tool          | Installation Guide | Version Check Command |
 |---------------|--------------------|-----------------------|
 | Git           | [Install Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) | `git --version` |
@@ -216,7 +216,6 @@ Congratulations! You have successfully deployed WSO2 Identity Server on Kubernet
 
 ## Install Helm chart on Azure Kubernetes service(AKS)
 
----
 ### Prerequisites
 * [Azure Kubernetes Service(AKS) with ACR integration](https://learn.microsoft.com/en-us/azure/aks/cluster-container-registry-integration?tabs=azure-cli).
 * Kubernetes ingress controller. Default integration is [Kubernetes Nginx ingress controller](https://github.com/kubernetes/ingress-nginx).
@@ -297,13 +296,13 @@ kubectl create secret generic keystores \
 ## 5. Create Azure storage account secret
 
 Create [Azure storage account secret](https://learn.microsoft.com/en-us/azure/aks/azure-csi-files-storage-provision#create-a-kubernetes-secret) for persistence volume.
-   
-Replace `<AZURE_STORAGE_NAME>` with Azure storage account name and `<AZURE_STORAGE_KEY>` with Azure storage account access key.
-  
+     
 ```shell
 export AZURE_STORAGE_NAME='<AZURE_STORAGE_NAME>'
 export AZURE_STORAGE_KEY='<AZURE_STORAGE_KEY>'
 ```
+
+Replace `<AZURE_STORAGE_NAME>` with Azure storage account name and `<AZURE_STORAGE_KEY>` with Azure storage account access key.
 
 ```shell
 kubectl create secret generic azure-storage-csi \
@@ -316,16 +315,17 @@ kubectl create secret generic azure-storage-csi \
 ## 6. Configure Azure key vault 
  
 - Add `internal.p12` keystore password as the secret with the name `INTERNAL-KEYSTORE-PASSWORD-DECRYPTED`. 
-- Replace: 
-    - `<AZURE_KEY_VAULT_NAME>` with Azure Key vault name 
-    - `<AZURE_SUBSCRIPTION_ID>` with Azure subscription ID 
-    - `<INTERNAL_KEYSTORE_PASSWORD_DECRYPTED>` with internal keystore (`internal.p12`) password.
 
     ```shell
     export AZURE_KEY_VAULT_NAME='<AZURE_KEY_VAULT_NAME>'
     export AZURE_SUBSCRIPTION_ID='<AZURE_SUBSCRIPTION_ID>'
     export INTERNAL_KEYSTORE_PASSWORD_DECRYPTED='<INTERNAL_KEYSTORE_PASSWORD_DECRYPTED>'
     ```
+
+- Replace: 
+    - `<AZURE_KEY_VAULT_NAME>` with Azure Key vault name 
+    - `<AZURE_SUBSCRIPTION_ID>` with Azure subscription ID 
+    - `<INTERNAL_KEYSTORE_PASSWORD_DECRYPTED>` with internal keystore (`internal.p12`) password.
 
 ```shell
 az login
@@ -335,14 +335,14 @@ az keyvault secret set --vault-name "${AZURE_KEY_VAULT_NAME}" --name "INTERNAL-K
 
 - Create a Kubernetes secret to hold service principal credentials to access keyvault for [secrets-store-csi-driver-provider-azure](https://azure.github.io/secrets-store-csi-driver-provider-azure/docs/configurations/identity-access-modes/service-principal-mode/). 
 
-- Replace: 
-    - `<AZURE_KEY_VAULT_SP_APP_ID>` with Azure active directory service principle application ID 
-    - `<AZURE_KEY_VAULT_SP_APP_SECRET>` with Azure active directory service principle application secret
-
     ```shell
     export AZURE_KEY_VAULT_SP_APP_ID='<AZURE_KEY_VAULT_SP_APP_ID>'
     export AZURE_KEY_VAULT_SP_APP_SECRET='<AZURE_KEY_VAULT_SP_APP_SECRET>'
     ```
+- Replace: 
+    - `<AZURE_KEY_VAULT_SP_APP_ID>` with Azure active directory service principle application ID 
+    - `<AZURE_KEY_VAULT_SP_APP_SECRET>` with Azure active directory service principle application secret
+
 
 ```shell
 kubectl create secret generic azure-kv-secret-store-sp \

--- a/confs/deployment.toml
+++ b/confs/deployment.toml
@@ -29,14 +29,16 @@ protocols={{ .Values.deploymentToml.transport.https.sslHostConfig.properties.pro
 ciphers={{ .Values.deploymentToml.transport.https.sslHostConfig.properties.ciphers | quote }}
 
 [super_admin]
+username = {{ .Values.deploymentToml.superAdmin.username | quote }}
 {{- if .Values.deployment.secretStore.enabled }}
-username = "$secret{super_admin_username}"
 password = "$secret{super_admin_password}"
 {{- else }}
-username = {{ .Values.deploymentToml.superAdmin.username | quote }}
 password = {{ .Values.deploymentToml.superAdmin.password | quote }}
 {{- end }}
 create_admin_account = {{ .Values.deploymentToml.superAdmin.createAdminAccount }}
+
+[identity_mgt]
+user_self_registration.callback_url = "https://{{ .Values.deployment.ingress.hostName }}/.*"
 
 [user_store]
 type = {{ .Values.deploymentToml.userStore.type | quote }}
@@ -174,6 +176,7 @@ password = "$secret{keystore_truststore_password}"
 {{- else }}
 password = {{ .Values.deploymentToml.truststore.password | quote }}
 {{- end }}
+
 [account_recovery.endpoint.auth]
 hash= {{ .Values.deploymentToml.account.recovery.endpoint.auth.hash | quote }}
 
@@ -250,6 +253,7 @@ enableAuthentication= {{ .Values.deploymentToml.outputAdapter.email.enableAuthen
 [event.default_listener.identity_mgt]
 priority= "50"
 enable = false
+
 [event.default_listener.governance_identity_mgt]
 priority= "95"
 enable = true
@@ -325,6 +329,7 @@ EnableAccountLockingForFailedAttempts = {{ .Values.deploymentToml.totp.userAccou
 {{- end }}
 
 [encryption]
+internal_crypto_provider = "org.wso2.carbon.crypto.provider.SymmetricKeyInternalCryptoProvider"
 {{- if .Values.deployment.secretStore.enabled }}
 key= "$secret{symmetric_key}"
 {{- else }}
@@ -334,9 +339,11 @@ key= {{ .Values.deploymentToml.encryption.key | quote }}
 {{- if .Values.deployment.secretStore.enabled }}
 # Secure vault encryted secrets
 [secrets]
+
 # Super admin creds
 super_admin_username = {{ .Values.deploymentToml.superAdmin.username | quote }}
 super_admin_password = {{ .Values.deploymentToml.superAdmin.password | quote }}
+
 # Database creds
 database_identity_username = {{ .Values.deploymentToml.database.identity.username | quote }}
 database_identity_password = {{ .Values.deploymentToml.database.identity.password | quote }}
@@ -346,6 +353,7 @@ database_user_username = {{ .Values.deploymentToml.database.user.username | quot
 database_user_password = {{ .Values.deploymentToml.database.user.password | quote }}
 database_consent_username = {{ .Values.deploymentToml.database.consent.username | quote }}
 database_consent_password = {{ .Values.deploymentToml.database.consent.password | quote }}
+
 # Keystores
 keystore_tls_password = {{ .Values.deploymentToml.keystore.tls.password | quote }}
 keystore_tls_key_password = {{ .Values.deploymentToml.keystore.tls.keyPassword | quote }}
@@ -353,13 +361,17 @@ keystore_primary_password = {{ .Values.deploymentToml.keystore.primary.password 
 keystore_primary_key_password = {{ .Values.deploymentToml.keystore.primary.keyPassword | quote }}
 keystore_internal_password = {{ .Values.deploymentToml.keystore.internal.password | quote }}
 keystore_internal_key_password = {{ .Values.deploymentToml.keystore.internal.keyPassword | quote }}
+
 # Truststore
 keystore_truststore_password = {{ .Values.deploymentToml.truststore.password | quote }}
+
 # App password
 app_password = {{ .Values.deploymentToml.identity.authFramework.endpoint.appPassword | quote }}
+
 # Symmetric key
 symmetric_key = {{ .Values.deploymentToml.encryption.key | quote }}
 {{- if .Values.deploymentToml.recaptcha.enabled }}
+
 # Recaptcha creds
 recaptcha_site_key = {{ .Values.deploymentToml.recaptcha.siteKey | quote }}
 recaptcha_secret_key = {{ .Values.deploymentToml.recaptcha.secretKey | quote }}
@@ -368,5 +380,4 @@ recaptcha_secret_key = {{ .Values.deploymentToml.recaptcha.secretKey | quote }}
 {{- if .Values.deploymentToml.outputAdapter.email.enabled }}
 output_adapter_email_password = {{ .Values.deploymentToml.outputAdapter.email.password | quote }}
 {{- end }}
-
 {{- end }}

--- a/confs/secret-conf.properties
+++ b/confs/secret-conf.properties
@@ -15,7 +15,7 @@
 # under the License.
 
 keystore.identity.location=/home/wso2carbon/{{ .Values.deployment.productPackName }}-{{ .Values.deployment.buildVersion }}/repository/resources/security/{{ .Values.deploymentToml.keystore.internal.fileName }}
-keystore.identity.type=JKS
+keystore.identity.type=PKCS12
 keystore.identity.alias={{ .Values.deploymentToml.keystore.internal.alias }}
 keystore.identity.store.password=identity.store.password
 keystore.identity.key.password=identity.key.password

--- a/templates/secret-provider-class.yaml
+++ b/templates/secret-provider-class.yaml
@@ -19,6 +19,7 @@ apiVersion: {{ .Values.k8sKindAPIVersions.secretProviderClass }}
 kind: SecretProviderClass
 metadata:
   name: {{ template "..fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   provider: azure
   parameters:

--- a/values.yaml
+++ b/values.yaml
@@ -59,7 +59,7 @@ deployment:
     # -- Container image digest
     digest: ""
     # -- Container image tag. Either "tag" or "digest" should defined
-    tag: "7.0.0"
+    tag: "7.1.0"
     # -- Refer to the Kubernetes documentation on updating images (Ref: https://kubernetes.io/docs/concepts/containers/images/#updating-images)
     pullPolicy: "Always"
     # -- image pull secret name
@@ -149,14 +149,14 @@ deployment:
         -Dhttpclient.hostnameVerifier=Strict -Djdk.tls.client.protocols=TLSv1.2
         -Djava.util.prefs.systemRoot=/home/wso2carbon/.java -Djava.util.prefs.userRoot=/home/wso2carbon/.java/.userPrefs
   # -- Product version
-  buildVersion: "7.0.0"
+  buildVersion: "7.1.0"
   # -- Product pack name
   productPackName: "wso2is"
   # -- Enable correlation logs
   enableCorrelationLogs: false
   externalJKS:
     # -- Mount external  keystore and trustores
-    enabled: false
+    enabled: true
     # -- K8s secret name which contains JKS files
     secretName: "keystores"
   persistence:
@@ -317,26 +317,26 @@ deploymentToml:
 #        defaultAutoCommit: false
   keystore:
     tls:
-      fileName: "wso2carbon.jks"
-      type: "JKS"
+      fileName: "tls.p12"
+      type: "PKCS12"
       password: "wso2carbon"
       alias: "wso2carbon"
       keyPassword: "wso2carbon"
     primary:
-      fileName: "wso2carbon.jks"
-      type: "JKS"
+      fileName: "primary.p12"
+      type: "PKCS12"
       password: "wso2carbon"
       alias: "wso2carbon"
       keyPassword: "wso2carbon"
     internal:
-      fileName: "wso2carbon.jks"
-      type: "JKS"
+      fileName: "internal.p12"
+      type: "PKCS12"
       password: "wso2carbon"
       alias: "wso2carbon"
       keyPassword: "wso2carbon"
   truststore:
-    fileName: "client-truststore.jks"
-    type: "JKS"
+    fileName: "client-truststore.p12"
+    type: "PKCS12"
     password: "wso2carbon"
   recaptcha:
     # -- Enable reCAPTCHA. Ref: https://is.docs.wso2.com/en/latest/deploy/configure-recaptcha/


### PR DESCRIPTION
## Purpose
- This PR introduces several improvements and adjustments to the Helm chart to support WSO2 Identity Server 7.1.0 and align with basic use cases.

## Issue
- https://github.com/wso2/product-is/issues/23379

## Goals
- Ensure compatibility with WSO2 Identity Server 7.1.0.
- Improve user onboarding via self-registration support.
- Align keystore formats with current standards.
- Enhance the documentation for easier setup and deployment.

## Changes Introduced
- Made external keystore mandatory: Required for secure internal and external communications in B2B scenarios.
- Added user_self_registration.callback_url to deployment.toml: Enables self-registration functionality.
- Updated keystore files to .p12 format: Standardizes keystore usage across internal, primary, TLS, and truststores.
- Updated image tags and build version to reflect WSO2 IS 7.1.0.
- Improved README documentation for better user experience and clarity during Helm-based deployment.