### PR TITLE
Fix imagepullsecrets in deployment

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -189,7 +189,7 @@ spec:
       serviceAccountName: {{ template "..fullname" . }}
       {{- if .Values.deployment.image.imagePullSecret }}
       imagePullSecrets:
-        - name: { { .Values.wso2.deployment.image.imagePullSecret }}
+        - name: {{ .Values.wso2.deployment.image.imagePullSecret }}
       {{- else if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
       imagePullSecrets:
         - name: {{ template "..fullname" . }}-wso2-private-registry-creds


### PR DESCRIPTION
## Purpose
Image pull secrets do not work currently.

## Goals
Fixes the helm formatting typo.

## Documentation
Relates to https://github.com/wso2/kubernetes-is/issues/334
