### PR TITLE
Add OpenShift support for IS helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,22 @@ If you used a custom password for keystores (instead of `wso2carbon`), provide i
 --set deploymentToml.truststore.password="<value>"
 ```
 
+#### Note: If you are using OpenShift, you need to set the following additional parameters:
+
+```bash
+--set deployment.securityContext.runAsUser.enabled=false \
+--set deployment.securityContext.seLinux.enabled=true \
+--set deployment.apparmor.enabled=false \
+--set deployment.entrypoint.defaultMode=0457
+```
+
+Or, if you need to disable Seccomp and AppArmor, set the following:
+
+```bash
+--set deployment.securityContext.seccompProfile.enabled=false \
+--set deployment.apparmor.enabled=false
+```
+
 ## 6. Obtain the External IP
 
 After deploying WSO2 Identity Server, you need to find its external IP address to access it outside the cluster. Run the following command to list the Ingress resources in your namespace:

--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ oc adm policy add-scc-to-user anyuid -z <service-acccount-name> -n <namespace>
 
 ## 4. Obtain the External IP
 
-
 After deploying WSO2 Identity Server, you need to find its external IP address to access it outside the cluster. Run the following command to list the Ingress resources in your namespace:
 
 ```shell

--- a/README.md
+++ b/README.md
@@ -183,7 +183,10 @@ If you used a custom password for keystores (instead of `wso2carbon`), provide i
 --set deployment.entrypoint.defaultMode=0457
 ```
 
-Or, if you need to disable Seccomp and AppArmor, set the following:
+Or, if you need to disable Seccomp and AppArmor and run with any UID, set the following:
+```bash
+oc adm policy add-scc-to-user anyuid -z <service-acccount-name> -n <namespace>
+```
 
 ```bash
 --set deployment.securityContext.seccompProfile.enabled=false \

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -44,9 +44,13 @@ spec:
         checksum.thrift-authentication.xml: {{ include (print $.Template.BasePath "/cm-thrift-authentication-xml.yaml") . | sha256sum }}
     spec:
       securityContext:
-        runAsUser: {{ .Values.deployment.securityContext.runAsUser }}
+        {{- if .Values.deployment.securityContext.runAsUser.enabled }}
+        runAsUser: {{ .Values.deployment.securityContext.runAsUser.uid }}
+        {{- end }}
+        {{- if .Values.deployment.securityContext.seccompProfile.enabled }}
         seccompProfile:
           type: {{ .Values.deployment.securityContext.seccompProfile.type }}
+        {{- end }}
       terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds }}
       affinity:
         podAntiAffinity:
@@ -124,6 +128,10 @@ spec:
             {{- if .Values.deployment.apparmor.enabled }}
             appArmorProfile: 
               type: {{ .Values.deployment.apparmor.profile }}
+            {{- end }}
+            {{- if .Values.deployment.securityContext.seLinux.enabled }}
+            seLinuxOptions:
+              level: {{ .Values.deployment.securityContext.seLinux.level }}
             {{- end }}
             capabilities:
               drop:
@@ -230,7 +238,7 @@ spec:
         - name: {{ template "..fullname" . }}-entrypoint
           configMap:
             name: {{ template "..fullname" . }}-entrypoint
-            defaultMode: 0407
+            defaultMode: {{ .values.deployment.entrypoint.defaultMode }}
         {{- if .Values.deployment.persistence.enabled }}
         - name: runtime-persistent-data-storage
           persistentVolumeClaim:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -238,7 +238,7 @@ spec:
         - name: {{ template "..fullname" . }}-entrypoint
           configMap:
             name: {{ template "..fullname" . }}-entrypoint
-            defaultMode: {{ .values.deployment.entrypoint.defaultMode }}
+            defaultMode: {{ .Values.deployment.configMaps.entryPoint.defaultMode }}
         {{- if .Values.deployment.persistence.enabled }}
         - name: runtime-persistent-data-storage
           persistentVolumeClaim:

--- a/values.yaml
+++ b/values.yaml
@@ -206,7 +206,6 @@ deployment:
         secretName: "INTERNAL-KEYSTORE-PASSWORD-DECRYPTED"
       # -- The name of the Kubernetes secret that contains the service principal credentials to access Azure Key Vault. Ref: https://azure.github.io/secrets-store-csi-driver-provider-azure/docs/configurations/identity-access-modes/service-principal-mode/#configure-service-principal-to-access-keyvault
       nodePublishSecretRef: "azure-kv-secret-store-sp"
-
   configMaps:
     entryPoint:
       defaultMode: "0407"

--- a/values.yaml
+++ b/values.yaml
@@ -87,10 +87,16 @@ deployment:
   #      name: custom-property-file
   securityContext:
     # -- Run as user ID
-    runAsUser: 802
+    runAsUser:
+      uid: 802
+      enabled: true
     seccompProfile:
+      enabled: true
     # --  Seccomp profile type
       type: "RuntimeDefault"
+    seLinux:
+      enabled: false
+      level: "s0:c26,c0"
   hpa:
     # -- Enable HPA for the deployment
     enabled: false
@@ -200,6 +206,10 @@ deployment:
         secretName: "INTERNAL-KEYSTORE-PASSWORD-DECRYPTED"
       # -- The name of the Kubernetes secret that contains the service principal credentials to access Azure Key Vault. Ref: https://azure.github.io/secrets-store-csi-driver-provider-azure/docs/configurations/identity-access-modes/service-principal-mode/#configure-service-principal-to-access-keyvault
       nodePublishSecretRef: "azure-kv-secret-store-sp"
+
+  configMaps:
+    entryPoint:
+      defaultMode: "0407"
 
 deploymentToml:
   server:


### PR DESCRIPTION
## Purpose
> Add OpenShift support for IS helm charts

## Goals
> Users should be able to deploy Identity Server in OpenShift using helm charts

## Approach
> 1. runAsUser: If you are using arbitrary UIDs, you can disable runAsUser by setting deployment.securityContext.runAsUser.enabled=false
> 2. seLinux Support: If you need SELinux support, you can enable it by setting deployment.securityContext.seLinux.enabled=true
> 3. AppArmor Support: If you need AppArmor disabled, you can do so by setting deployment.apparmor.enabled=false
> 4. ConfigMap Access: If your runtime user doesn't have execute access to ConfigMaps, you can fix it by setting deployment.entrypoint.defaultMode=0457
