### PR TITLE
Add AWS Compatibility for Helm Deployment

### DIFF
--- a/aws-secrets-injector/README.md
+++ b/aws-secrets-injector/README.md
@@ -1,0 +1,23 @@
+# AWS Secrets Injector
+
+This project provides a lightweight, secure init container designed to fetch secrets from AWS Secrets Manager and make them available to other containers in a Kubernetes Pod.
+
+The injector is written in Go and built into a minimal, non-root, distroless Docker image for enhanced security. It leverages IAM Roles for Service Accounts (IRSA) in Kubernetes to securely authenticate with AWS without needing static credentials.
+
+## Configuration
+
+The init container is configured using three environment variables:
+
+| Variable       | Description                                                                 | Example                               |
+| -------------- | --------------------------------------------------------------------------- | ------------------------------------- |
+| `SECRET_NAME`  | The name or ARN of the secret to fetch from AWS Secrets Manager.            | `my-app/secrets/production`           |
+| `AWS_REGION`   | The AWS region where the secret is stored.                                  | `us-east-1`                           |
+| `OUTPUT_PATH`  | The full path within the container where the secret content will be written. | `/secrets/db-password.txt`            |
+
+## Building the Container
+
+To build the Docker image from the source code, navigate to the project's root directory and run the following command:
+
+```bash
+docker build -t application/aws-secrets-injector:latest -f build/Dockerfile .
+

--- a/aws-secrets-injector/README.md
+++ b/aws-secrets-injector/README.md
@@ -20,3 +20,4 @@ To build the Docker image from the source code, navigate to the project's root d
 
 ```bash
 docker build -t application/aws-secrets-injector:latest -f build/Dockerfile .
+```

--- a/aws-secrets-injector/README.md
+++ b/aws-secrets-injector/README.md
@@ -20,4 +20,3 @@ To build the Docker image from the source code, navigate to the project's root d
 
 ```bash
 docker build -t application/aws-secrets-injector:latest -f build/Dockerfile .
-

--- a/aws-secrets-injector/application/secret-injector/main.go
+++ b/aws-secrets-injector/application/secret-injector/main.go
@@ -1,0 +1,89 @@
+// -------------------------------------------------------------------------------------
+//
+// Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+//
+// This software is the property of WSO2 LLC. and its suppliers, if any.
+// Dissemination of any information or reproduction of any material contained
+// herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+// You may not alter or remove any copyright or other notice from copies of this content.
+//
+// --------------------------------------------------------------------------------------
+
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+
+	// Fetch configuration from environment variables
+	secretName := os.Getenv("SECRET_NAME")
+	awsRegion := os.Getenv("AWS_REGION")
+	outputFilePath := os.Getenv("OUTPUT_PATH")
+
+	// Validate that all required environment variables are set and exit if not
+	if secretName == "" || awsRegion == "" || outputFilePath == "" {
+		log.Fatal("Error: Required environment variables (SECRET_NAME, AWS_REGION, OUTPUT_PATH) are not set.")
+	}
+	log.Printf("Starting secret retrieval for '%s' in region '%s'", secretName, awsRegion)
+
+	// Create a new AWS session
+	sess, err := session.NewSession()
+	if err != nil {
+		log.Fatalf("Failed to create new AWS session: %v", err)
+	}
+
+	svc := secretsmanager.New(sess, &aws.Config{
+		Region: aws.String(awsRegion),
+	})
+
+	input := &secretsmanager.GetSecretValueInput{
+		SecretId:     aws.String(secretName),
+		VersionStage: aws.String("AWSCURRENT"),
+	}
+
+	// Retrieve the secret value
+	result, err := svc.GetSecretValue(input)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			log.Fatalf("AWS Error retrieving secret. Code: %s, Message: %s", aerr.Code(), aerr.Error())
+		} else {
+			log.Fatalf("Unknown error retrieving secret: %v", err.Error())
+		}
+	}
+
+	// Handle both string and binary secrets
+	var secretValue string
+	if result.SecretString != nil {
+		secretValue = *result.SecretString
+		log.Println("Secret successfully retrieved as a string.")
+	} else {
+		decodedBinarySecretBytes := make([]byte, base64.StdEncoding.DecodedLen(len(result.SecretBinary)))
+		len, err := base64.StdEncoding.Decode(decodedBinarySecretBytes, result.SecretBinary)
+		if err != nil {
+			log.Fatalf("Failed to decode binary secret from base64: %v", err)
+		}
+		secretValue = string(decodedBinarySecretBytes[:len])
+		log.Println("Secret successfully retrieved as binary and decoded.")
+	}
+
+	// Write the secret to the configured output file
+	err = os.WriteFile(outputFilePath, []byte(secretValue), 0644)
+	if err != nil {
+		log.Fatalf("Failed to write secret to file '%s': %v", outputFilePath, err)
+	}
+
+	log.Printf("Secret written successfully to %s", outputFilePath)
+	fmt.Println("Process completed successfully.")
+}
+

--- a/aws-secrets-injector/build/Dockerfile
+++ b/aws-secrets-injector/build/Dockerfile
@@ -1,0 +1,22 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein in any form is strictly forbidden, unless permitted by WSO2 expressly.
+# You may not alter or remove any copyright or other notice from copies of this content.
+#
+# --------------------------------------------------------------------------------------
+
+FROM golang:1.22-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY ./application ./application
+RUN go build -ldflags="-w -s" -o /app -v ./application/secret-injector
+FROM gcr.io/distroless/static-debian12
+COPY --from=build /app /app
+USER nonroot:nonroot
+ENTRYPOINT ["/app"]
+

--- a/aws-secrets-injector/build/Dockerfile
+++ b/aws-secrets-injector/build/Dockerfile
@@ -10,13 +10,20 @@
 # --------------------------------------------------------------------------------------
 
 FROM golang:1.22-alpine AS build
+
+# Set the working directory inside the container & copy go.mod and go.sum files to enable dependency caching
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
+
+# Copy the application source code into the container & build the Go application
 COPY ./application ./application
 RUN go build -ldflags="-w -s" -o /app -v ./application/secret-injector
+
+# Use a minimal runtime image & copy the compiled Go binary
 FROM gcr.io/distroless/static-debian12
 COPY --from=build /app /app
 USER nonroot:nonroot
-ENTRYPOINT ["/app"]
 
+# Define the entrypoint to run the application
+ENTRYPOINT ["/app"]

--- a/aws-secrets-injector/go.mod
+++ b/aws-secrets-injector/go.mod
@@ -1,0 +1,8 @@
+module github.com/wso2/aws-secrets-injector
+
+go 1.18
+
+require github.com/aws/aws-sdk-go v1.54.9
+
+require github.com/jmespath/go-jmespath v0.4.0
+

--- a/aws-secrets-injector/go.mod
+++ b/aws-secrets-injector/go.mod
@@ -1,8 +1,4 @@
 module github.com/wso2/aws-secrets-injector
-
 go 1.18
-
 require github.com/aws/aws-sdk-go v1.54.9
-
 require github.com/jmespath/go-jmespath v0.4.0
-

--- a/aws-secrets-injector/go.sum
+++ b/aws-secrets-injector/go.sum
@@ -1,0 +1,15 @@
+github.com/aws/aws-sdk-go v1.54.9 h1:e0Czh9AhrCVPuyaIUnibYmih3cYexJKlqlHSJ2eMKbI=
+github.com/aws/aws-sdk-go v1.54.9/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+

--- a/aws-secrets-injector/go.sum
+++ b/aws-secrets-injector/go.sum
@@ -12,4 +12,3 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-

--- a/confs/secret-conf.properties
+++ b/confs/secret-conf.properties
@@ -24,16 +24,14 @@ keystore.identity.key.secretProvider=org.wso2.carbon.securevault.DefaultSecretCa
 carbon.secretProvider=org.wso2.securevault.secret.handler.SecretManagerSecretCallbackHandler
 secVault.enabled=true
 
-{{- if .Values.deployment.secretStore.azure.enabled  }}
-secretRepositories=file
-secretRepositories.file.provider=org.wso2.securevault.secret.repository.FileBaseSecretRepositoryProvider
-secretRepositories.file.location=repository/conf/security/cipher-text.properties
-{{- end }}
-
 {{- if .Values.deployment.secretStore.aws.enabled  }}
 secretRepositories=vault
 secretRepositories.vault.provider=org.wso2.carbon.securevault.aws.secret.repository.AWSSecretRepositoryProvider
 secretRepositories.vault.properties.awsregion={{ .Values.deployment.secretStore.aws.secretManager.region }}
 secretRepositories.vault.properties.credentialProviders=k8sServiceAccount
 secretRepositories.vault.properties.encryptionEnabled=true
+{{- else  }}
+secretRepositories=file
+secretRepositories.file.provider=org.wso2.securevault.secret.repository.FileBaseSecretRepositoryProvider
+secretRepositories.file.location=repository/conf/security/cipher-text.properties
 {{- end }}

--- a/confs/secret-conf.properties
+++ b/confs/secret-conf.properties
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -19,11 +19,21 @@ keystore.identity.type=PKCS12
 keystore.identity.alias={{ .Values.deploymentToml.keystore.internal.alias }}
 keystore.identity.store.password=identity.store.password
 keystore.identity.key.password=identity.key.password
-
+keystore.identity.store.secretProvider=org.wso2.carbon.securevault.DefaultSecretCallbackHandler
+keystore.identity.key.secretProvider=org.wso2.carbon.securevault.DefaultSecretCallbackHandler
 carbon.secretProvider=org.wso2.securevault.secret.handler.SecretManagerSecretCallbackHandler
 secVault.enabled=true
+
+{{- if .Values.deployment.secretStore.azure.enabled  }}
 secretRepositories=file
 secretRepositories.file.provider=org.wso2.securevault.secret.repository.FileBaseSecretRepositoryProvider
 secretRepositories.file.location=repository/conf/security/cipher-text.properties
-keystore.identity.store.secretProvider=org.wso2.carbon.securevault.DefaultSecretCallbackHandler
-keystore.identity.key.secretProvider=org.wso2.carbon.securevault.DefaultSecretCallbackHandler
+{{- end }}
+
+{{- if .Values.deployment.secretStore.aws.enabled  }}
+secretRepositories=vault
+secretRepositories.vault.provider=org.wso2.carbon.securevault.aws.secret.repository.AWSSecretRepositoryProvider
+secretRepositories.vault.properties.awsregion={{ .Values.deployment.secretStore.aws.secretManager.region }}
+secretRepositories.vault.properties.credentialProviders=k8sServiceAccount
+secretRepositories.vault.properties.encryptionEnabled=true
+{{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -67,3 +67,31 @@ Selector labels
 app.kubernetes.io/name: {{ include "..name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Validate Cloud Provider Specific Configurations..
+*/}}
+{{- define "..validateCloudProviderConfig" -}}
+  {{- $values := .Values.deployment -}}
+
+  {{/* Validate Ingress Configuration */}}
+  {{- $ingressAwsEnabled := and (hasKey $values.ingress "aws") $values.ingress.aws.enabled }}
+  {{- $ingressAzureEnabled := and (hasKey $values.ingress "azure") $values.ingress.azure.enabled }}
+  {{- if and $ingressAwsEnabled $ingressAzureEnabled }}
+    {{- fail (printf "Validation Error in 'deployment.ingress': Both 'aws.enabled' (value: %v) and 'azure.enabled' (value: %v) are true. Only one cloud provider should be enabled for Ingress at a time." $values.ingress.aws.enabled $values.ingress.azure.enabled) }}
+  {{- end }}
+
+  {{/* Validate Persistence Configuration */}}
+  {{- $persistenceAwsEnabled := and (hasKey $values.persistence "aws") $values.persistence.aws.enabled }}
+  {{- $persistenceAzureEnabled := and (hasKey $values.persistence "azure") $values.persistence.azure.enabled }}
+  {{- if and $persistenceAwsEnabled $persistenceAzureEnabled }}
+    {{- fail (printf "Validation Error in 'deployment.persistence': Both 'aws.enabled' (value: %v) and 'azure.enabled' (value: %v) are true. Only one cloud provider should be enabled for Persistence at a time." $values.persistence.aws.enabled $values.persistence.azure.enabled) }}
+  {{- end }}
+
+  {{/* Validate SecretStore Configuration */}}
+  {{- $secretStoreAwsEnabled := and (hasKey $values.secretStore "aws") $values.secretStore.aws.enabled }}
+  {{- $secretStoreAzureEnabled := and (hasKey $values.secretStore "azure") $values.secretStore.azure.enabled }}
+  {{- if and $secretStoreAwsEnabled $secretStoreAzureEnabled }}
+    {{- fail (printf "Validation Error in 'deployment.secretStore': Both 'aws.enabled' (value: %v) and 'azure.enabled' (value: %v) are true. Only one cloud provider should be enabled for SecretStore at a time." $values.secretStore.aws.enabled $values.secretStore.azure.enabled) }}
+  {{- end }}
+{{- end -}}

--- a/templates/cm-entrypoint.yaml
+++ b/templates/cm-entrypoint.yaml
@@ -55,12 +55,12 @@ data:
     # copy any artifact changes mounted to artifact_volume
     test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
     
-    {{- if .Values.deployment.secretStore.azure.enabled }}
+    {{- if and .Values.deployment.secretStore.enabled .Values.deployment.secretStore.azure.enabled }}
     # copy the decrypted internal keystore password to the password-tmp file
     cp /mnt/secrets-store/INTERNAL-KEYSTORE-PASSWORD-DECRYPTED ${WSO2_SERVER_HOME}/password-tmp
     {{- end }}
 
-    {{- if .Values.deployment.secretStore.aws.enabled }}
+    {{- if and .Values.deployment.secretStore.enabled .Values.deployment.secretStore.aws.enabled }}
     cp /mnt/secrets-store/password-tmp ${WSO2_SERVER_HOME}/password-tmp
     {{- end }}
     

--- a/templates/cm-entrypoint.yaml
+++ b/templates/cm-entrypoint.yaml
@@ -55,7 +55,9 @@ data:
     # copy any artifact changes mounted to artifact_volume
     test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
     
-    {{- if .Values.deployment.secretStore.enabled }}
+    {{- if .Values.deployment.secretStore.aws.enabled }}
+    cp /mnt/secrets-store/password-tmp ${WSO2_SERVER_HOME}/password-tmp
+    {{- if .Values.deployment.secretStore.azure.enabled }}
     # copy the decrypted internal keystore password to the password-tmp file
     cp /mnt/secrets-store/INTERNAL-KEYSTORE-PASSWORD-DECRYPTED ${WSO2_SERVER_HOME}/password-tmp
     {{- end }}

--- a/templates/cm-entrypoint.yaml
+++ b/templates/cm-entrypoint.yaml
@@ -55,11 +55,13 @@ data:
     # copy any artifact changes mounted to artifact_volume
     test -d ${artifact_volume} && [ "$(ls -A ${artifact_volume})" ] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
     
-    {{- if .Values.deployment.secretStore.aws.enabled }}
-    cp /mnt/secrets-store/password-tmp ${WSO2_SERVER_HOME}/password-tmp
     {{- if .Values.deployment.secretStore.azure.enabled }}
     # copy the decrypted internal keystore password to the password-tmp file
     cp /mnt/secrets-store/INTERNAL-KEYSTORE-PASSWORD-DECRYPTED ${WSO2_SERVER_HOME}/password-tmp
+    {{- end }}
+
+    {{- if .Values.deployment.secretStore.aws.enabled }}
+    cp /mnt/secrets-store/password-tmp ${WSO2_SERVER_HOME}/password-tmp
     {{- end }}
     
     # start WSO2 Carbon server

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -48,6 +48,7 @@ spec:
         {{- if .Values.deployment.secretStore.aws.enabled }}
         secret.k8s.aws/secret-name: {{ .Values.deployment.secretStore.aws.secretManager.secretName }}
         secret.k8s.aws/region: {{ .Values.deployment.secretStore.aws.secretManager.region }}
+        secret.k8s.aws/output-path: {{ .Values.deployment.secretStore.aws.secretManager.outputPath }}
         {{- end }}
     spec:
       securityContext:
@@ -77,8 +78,12 @@ spec:
                 topologyKey: topology.kubernetes.io/zone
       {{- if .Values.deployment.secretStore.aws.enabled }}
       initContainers:
-        - name: aws-secrets-manager
-          image: loshans/secret-access-init:latest
+        - name: aws-secrets-injector
+          {{- if .Values.deployment.secretStore.aws.secretManager.image.digest }}
+          image: {{ .Values.deployment.secretStore.aws.secretManager.image.registry }}/{{ .Values.deployment.secretStore.aws.secretManager.image.repository }}@{{ .Values.deployment.secretStore.aws.secretManager.image.digest }}
+          {{- else }}
+          image: {{ .Values.deployment.secretStore.aws.secretManager.image.registry }}/{{ .Values.deployment.secretStore.aws.secretManager.image.repository }}:{{ default "latest" .Values.deployment.secretStore.aws.secretManager.image.tag }}
+          {{- end }}
           env:
             - name: AWS_REGION
               valueFrom:
@@ -88,6 +93,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.annotations['secret.k8s.aws/secret-name']
+            - name: OUTPUT_PATH
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['secret.k8s.aws/output-path']
           volumeMounts:
             - name: secrets-volume
               mountPath: /tmp

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -13,6 +13,7 @@
 # KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations
 # under the License.
+{{- include "..validateCloudProviderConfig" . }}
 
 apiVersion: {{ .Values.k8sKindAPIVersions.deployment }}
 kind: Deployment

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -42,6 +42,13 @@ spec:
         checksum.log4j.properties: {{ include (print $.Template.BasePath "/cm-log4j2-properties.yaml") . | sha256sum }}
         checksum.entrypoint.sh: {{ include (print $.Template.BasePath "/cm-entrypoint.yaml") . | sha256sum }}
         checksum.thrift-authentication.xml: {{ include (print $.Template.BasePath "/cm-thrift-authentication-xml.yaml") . | sha256sum }}
+        {{- if .Values.deployment.apparmor.enabled }}
+        container.apparmor.security.beta.kubernetes.io/wso2is: {{ .Values.deployment.apparmor.profile }}
+        {{- end }}
+        {{- if .Values.deployment.secretStore.aws.enabled }}
+        secret.k8s.aws/secret-name: {{ .Values.deployment.secretStore.aws.secretManager.secretName }}
+        secret.k8s.aws/region: {{ .Values.deployment.secretStore.aws.secretManager.region }}
+        {{- end }}
     spec:
       securityContext:
         {{- if .Values.deployment.securityContext.runAsUser.enabled }}
@@ -68,6 +75,31 @@ spec:
                       values:
                         - {{ .Release.Name }}
                 topologyKey: topology.kubernetes.io/zone
+      {{- if .Values.deployment.secretStore.aws.enabled }}
+      initContainers:
+        - name: aws-secrets-manager
+          image: loshans/secret-access-init:latest
+          env:
+            - name: AWS_REGION
+              valueFrom:
+                fieldRef: 
+                  fieldPath: metadata.annotations['secret.k8s.aws/region']
+            - name: SECRET_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['secret.k8s.aws/secret-name']
+          volumeMounts:
+            - name: secrets-volume
+              mountPath: /tmp
+          securityContext:
+            allowPrivilegeEscalation: false
+            # File system should be read write to cater runtime writes to the configs, DB files, etc...
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - all
+      {{- end }}
       containers:
         - name: wso2is
           {{- if .Values.deployment.image.digest }}
@@ -224,6 +256,7 @@ spec:
         - name: {{ template "..fullname" . }}-secret-config-properties
           configMap:
             name: {{ template "..fullname" . }}-secret-config-properties
+        {{- if .Values.deployment.secretStore.azure.enabled }}
         - name: secrets-volume
           csi:
             driver: secrets-store.csi.k8s.io
@@ -234,6 +267,11 @@ spec:
             nodePublishSecretRef:
               name: {{ .Values.deployment.secretStore.azure.nodePublishSecretRef }}
             {{- end }}
+        {{- end }}
+        {{- if .Values.deployment.secretStore.aws.enabled }}
+        - name: secrets-volume
+          emptyDir: {}
+        {{- end }}
         {{- end }}
         - name: {{ template "..fullname" . }}-entrypoint
           configMap:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -18,8 +18,10 @@ apiVersion: {{ .Values.k8sKindAPIVersions.ingress }}
 kind: Ingress
 metadata:
   annotations:
-    {{- if .Values.deployment.ingress.annotations }}
-    {{- toYaml .Values.deployment.ingress.annotations | nindent 4 }}
+    {{- if .Values.deployment.ingress.aws.enabled }}
+    {{- toYaml .Values.deployment.ingress.aws.annotations | nindent 4 }}
+    {{- else }}
+    {{- toYaml .Values.deployment.ingress.azure.annotations | nindent 4 }}
     {{- end }}
   namespace:  {{ .Release.Namespace }}
   name: {{ template "..fullname" . }}

--- a/templates/pv.yaml
+++ b/templates/pv.yaml
@@ -44,11 +44,11 @@ spec:
     - dir_mode=0777
     - file_mode=0777
     - uid={{ .Values.deployment.securityContext.runAsUser }}
-{{- if .Values.deployment.securityContext.enableRunAsGroup }}
-    - gid={{ .Values.deployment.securityContext.runAsGroup }}
-{{- else }}
-    - gid={{ .Values.deployment.securityContext.runAsUser }}
-{{- end }}
+    - gid={{- if .Values.deployment.securityContext.enableRunAsGroup }}
+          {{ .Values.deployment.securityContext.runAsGroup }}
+      {{- else }}
+          {{ .Values.deployment.securityContext.runAsUser }}
+      {{- end }}
     - cache=strict
   {{- else if .Values.deployment.persistence.aws.enabled }}
   csi:

--- a/templates/pv.yaml
+++ b/templates/pv.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.persistence.enabled }}
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -15,13 +15,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
-{{- if .Values.deployment.persistence.azure.enabled }}
 apiVersion: {{ .Values.k8sKindAPIVersions.persistentVolume }}
 kind: PersistentVolume
 metadata:
   name: {{ template "..fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     purpose: {{ template "..fullname" . }}-identity-server-persistence
+  {{- if .Values.deployment.persistence.aws.enabled }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
 spec:
   accessModes:
     - ReadWriteMany
@@ -29,6 +35,7 @@ spec:
     storage: {{ .Values.deployment.persistence.capacity }}
   persistentVolumeReclaimPolicy: Retain
   volumeMode: Filesystem
+  {{- if .Values.deployment.persistence.azure.enabled }}
   azureFile:
     secretName: {{ .Values.deployment.persistence.azure.secretName }}
     secretNamespace: {{ .Release.Namespace }}
@@ -39,5 +46,9 @@ spec:
     - uid={{ .Values.deployment.securityContext.runAsUser }}
     - gid={{ .Values.deployment.securityContext.runAsUser }}
     - cache=strict
-{{- end }}
+  {{- else if .Values.deployment.persistence.aws.enabled }}
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: {{ .Values.deployment.persistence.aws.volumeHandle }}
+  {{- end }}
 {{- end }}

--- a/templates/pvc-wait-hook-job.yaml
+++ b/templates/pvc-wait-hook-job.yaml
@@ -17,7 +17,7 @@
 {{- if .Values.deployment.persistence.enabled }}
 {{- if .Values.deployment.persistence.aws.enabled }}
 ---
-apiVersion: batch/v1
+apiVersion: {{ .Values.k8sKindAPIVersions.job }}
 kind: Job
 metadata:
   name: {{ .Release.Name }}-wait-for-pvc-job

--- a/templates/pvc-wait-hook-job.yaml
+++ b/templates/pvc-wait-hook-job.yaml
@@ -14,8 +14,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-{{- if .Values.deployment.persistence.enabled }}
-{{- if .Values.deployment.persistence.aws.enabled }}
+{{- if and .Values.deployment.persistence.enabled .Values.deployment.persistence.aws.enabled }}
 ---
 apiVersion: {{ .Values.k8sKindAPIVersions.job }}
 kind: Job
@@ -55,5 +54,4 @@ spec:
                 exit 1
               fi
       restartPolicy: Never
-{{- end }}
 {{- end }}

--- a/templates/pvc-wait-hook-job.yaml
+++ b/templates/pvc-wait-hook-job.yaml
@@ -46,7 +46,7 @@ spec:
               PVC_NAME="{{ template "..fullname" . }}"
               NAMESPACE="{{ .Release.Namespace }}"
               echo "Waiting up to 1m for PVC $PVC_NAME in namespace $NAMESPACE to be Bound..."
-              if kubectl pvc "$PVC_NAME" -n "$NAMESPACE" --for=jsonpath='{.status.phase}'=Bound wait --timeout=1m; then
+              if kubectl wait pvc "$PVC_NAME" -n "$NAMESPACE" --for=jsonpath='{.status.phase}'=Bound --timeout=1m; then
                 echo "PVC $PVC_NAME is Bound!"
                 exit 0
               else

--- a/templates/pvc-wait-hook-job.yaml
+++ b/templates/pvc-wait-hook-job.yaml
@@ -1,0 +1,59 @@
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{{- if .Values.deployment.persistence.enabled }}
+{{- if .Values.deployment.persistence.aws.enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-wait-for-pvc-job
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-pvc-wait
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+       labels:
+          app: {{ .Release.Name }}-pvc-wait
+          job-name: {{ .Release.Name }}-wait-for-pvc-job
+    spec:
+      serviceAccountName: {{ .Release.Name }}-pvc-wait-sa
+      containers:
+        - name: wait
+          image: bitnami/kubectl:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              PVC_NAME="{{ template "..fullname" . }}"
+              NAMESPACE="{{ .Release.Namespace }}"
+              echo "Waiting up to 1m for PVC $PVC_NAME in namespace $NAMESPACE to be Bound..."
+              if kubectl pvc "$PVC_NAME" -n "$NAMESPACE" --for=jsonpath='{.status.phase}'=Bound wait --timeout=1m; then
+                echo "PVC $PVC_NAME is Bound!"
+                exit 0
+              else
+                echo "Error: Timeout waiting for PVC $PVC_NAME to become Bound." >&2
+                kubectl get pvc "$PVC_NAME" -n "$NAMESPACE" -o yaml 
+                exit 1
+              fi
+      restartPolicy: Never
+{{- end }}
+{{- end }}

--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.deployment.persistence.enabled }}
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -19,7 +19,13 @@ apiVersion: {{ .Values.k8sKindAPIVersions.persistentVolumeClaim }}
 kind: PersistentVolumeClaim
 metadata:
   name: {{ template "..fullname" . }}
-  namespace : {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.deployment.persistence.aws.enabled }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-2"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- end }}
 spec:
   accessModes:
     - ReadWriteMany

--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -21,7 +21,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- if .Values.deployment.persistence.aws.enabled }}
   annotations:
-    {{- toYaml .Values.deployment.rbac.annotations | nindent 4 }}
+    {{- toYaml .Values.deployment.rbac.aws.annotations | nindent 4 }}
   {{- end }}
 
 ---
@@ -65,8 +65,8 @@ metadata:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-5" 
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-    {{- if .Values.deployment.rbac.annotations }}
-    {{- toYaml .Values.deployment.rbac.annotations | nindent 4 }}
+    {{- if .Values.deployment.rbac.aws.annotations }}
+    {{- toYaml .Values.deployment.rbac.aws.annotations | nindent 4 }}
     {{- end }}
 
 ---

--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -54,7 +54,7 @@ subjects:
 
 {{- if and .Values.deployment.persistence.enabled .Values.deployment.persistence.aws.enabled }}
 ---
-apiVersion: v1
+apiVersion: {{ .Values.k8sKindAPIVersions.serviceAccount }}
 kind: ServiceAccount
 metadata:
   name: {{ .Release.Name }}-pvc-wait-sa 
@@ -71,7 +71,7 @@ metadata:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ .Values.k8sKindAPIVersions.role }}
 kind: Role
 metadata:
   name: {{ .Release.Name }}-pvc-wait-role
@@ -89,7 +89,7 @@ rules:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: {{ .Values.k8sKindAPIVersions.roleBinding }}
 kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}-pvc-wait-binding

--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -18,7 +18,15 @@ apiVersion: {{ .Values.k8sKindAPIVersions.serviceAccount }}
 kind: ServiceAccount
 metadata:
   name: {{ template "..fullname" . }}
-  namespace : {{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}
+  {{- if or .Values.deployment.persistence.aws.enabled .Values.deployment.rbac.annotations }}
+  annotations:
+    {{- if .Values.deployment.persistence.aws.enabled }}
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- end }}
+  {{- end }}
 
 ---
 
@@ -47,3 +55,61 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "..fullname" . }}
     namespace: {{ .Release.Namespace }}
+
+{{- if and .Values.deployment.persistence.enabled .Values.deployment.persistence.aws.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "wso2is.fullname" . }}-pvc-wait-sa
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "wso2is.fullname" . }}-pvc-wait
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- if .Values.deployment.rbac.annotations }}
+    {{- toYaml .Values.deployment.rbac.annotations | nindent 4 }}
+    {{- end }}
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "wso2is.fullname" . }}-pvc-wait-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "wso2is.fullname" . }}-pvc-wait
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["get", "list", "watch"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "wso2is.fullname" . }}-pvc-wait-binding
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "wso2is.fullname" . }}-pvc-wait
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "wso2is.fullname" . }}-pvc-wait-role
+subjects:
+- kind: ServiceAccount
+  name: {{ template "wso2is.fullname" . }}-pvc-wait-sa
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -19,13 +19,9 @@ kind: ServiceAccount
 metadata:
   name: {{ template "..fullname" . }}
   namespace: {{ .Release.Namespace }}
-  {{- if or .Values.deployment.persistence.aws.enabled .Values.deployment.rbac.annotations }}
+  {{- if .Values.deployment.persistence.aws.enabled }}
   annotations:
-    {{- if .Values.deployment.persistence.aws.enabled }}
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-    {{- end }}
+    {{- toYaml .Values.deployment.rbac.annotations | nindent 4 }}
   {{- end }}
 
 ---
@@ -61,13 +57,13 @@ subjects:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "..fullname" . }}-pvc-wait-sa
+  name: {{ .Release.Name }}-pvc-wait-sa 
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "..fullname" . }}-pvc-wait
+    app: {{ .Release.Name }}-pvc-wait
   annotations:
     "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-weight": "-5" 
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     {{- if .Values.deployment.rbac.annotations }}
     {{- toYaml .Values.deployment.rbac.annotations | nindent 4 }}
@@ -78,16 +74,16 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "..fullname" . }}-pvc-wait-role
+  name: {{ .Release.Name }}-pvc-wait-role
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "..fullname" . }}-pvc-wait
+     app: {{ .Release.Name }}-pvc-wait
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
-- apiGroups: [""]
+- apiGroups: [""] 
   resources: ["persistentvolumeclaims"]
   verbs: ["get", "list", "watch"]
 
@@ -96,10 +92,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "..fullname" . }}-pvc-wait-binding
+  name: {{ .Release.Name }}-pvc-wait-binding
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "..fullname" . }}-pvc-wait
+     app: {{ .Release.Name }}-pvc-wait
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-5"
@@ -107,9 +103,10 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "..fullname" . }}-pvc-wait-role
+  name: {{ .Release.Name }}-pvc-wait-role 
 subjects:
 - kind: ServiceAccount
-  name: {{ template "..fullname" . }}-pvc-wait-sa
+  name: {{ .Release.Name }}-pvc-wait-sa
   namespace: {{ .Release.Namespace }}
+  storageClassName: ""
 {{- end }}

--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -61,10 +61,10 @@ subjects:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "wso2is.fullname" . }}-pvc-wait-sa
+  name: {{ template "..fullname" . }}-pvc-wait-sa
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "wso2is.fullname" . }}-pvc-wait
+    app: {{ template "..fullname" . }}-pvc-wait
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-5"
@@ -78,10 +78,10 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "wso2is.fullname" . }}-pvc-wait-role
+  name: {{ template "..fullname" . }}-pvc-wait-role
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "wso2is.fullname" . }}-pvc-wait
+    app: {{ template "..fullname" . }}-pvc-wait
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-5"
@@ -96,10 +96,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "wso2is.fullname" . }}-pvc-wait-binding
+  name: {{ template "..fullname" . }}-pvc-wait-binding
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "wso2is.fullname" . }}-pvc-wait
+    app: {{ template "..fullname" . }}-pvc-wait
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "-5"
@@ -107,9 +107,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "wso2is.fullname" . }}-pvc-wait-role
+  name: {{ template "..fullname" . }}-pvc-wait-role
 subjects:
 - kind: ServiceAccount
-  name: {{ template "wso2is.fullname" . }}-pvc-wait-sa
+  name: {{ template "..fullname" . }}-pvc-wait-sa
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -50,7 +50,7 @@ deployment:
       # Sets the size of the buffer proxy_buffer_size used for reading the first part of the response received from the proxied server. By default proxy buffer size is set as "64k".(Ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#proxy-buffer-size)
       nginx.ingress.kubernetes.io/proxy-buffer-size: "64k"
     azure:
-      enabled: false
+      enabled: true
       annotations:
         !!merge <<: *commonAnnotations
         nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
@@ -60,8 +60,9 @@ deployment:
         !!merge <<: *commonAnnotations
         nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
   rbac:
-    annotations:
-      eks.amazonaws.com/role-arn: "null"
+    aws:
+      annotations:
+        eks.amazonaws.com/role-arn: "null"
   image:
     # -- Container image registry host name
     registry: "docker.wso2.com"
@@ -188,7 +189,7 @@ deployment:
       userstores: "userstores"
     azure:
       # -- Enable persistence for artifact sharing using Azure file share
-      enabled: false
+      enabled: true
       # -- Azure Storage Account credentials to access the file shares
       # -- Ref: https://docs.microsoft.com/en-us/azure/aks/azure-files-volume#create-a-kubernetes-secret
       # -- Names of Azure File shares for persisted data
@@ -207,7 +208,7 @@ deployment:
     enabled: false
     azure:
       # -- Enable Azure Key Vault integration.
-      enabled: false
+      enabled: true
       keyVault:
         # -- Name of the target Azure Key Vault instance
         name: ""
@@ -541,7 +542,6 @@ k8sKindAPIVersions:
   csi: "storage.k8s.io/v1"
   # -- K8s API version for kind Job
   job: "batch/v1"
-  
 # -- OpenShift API versions for OpenShift kinds
 openShiftKindAPIVersions:
   # -- OpenShift API version for kind Route

--- a/values.yaml
+++ b/values.yaml
@@ -539,6 +539,9 @@ k8sKindAPIVersions:
   service: "v1"
   # -- k8s API verion for CSI Driver
   csi: "storage.k8s.io/v1"
+  # -- K8s API version for kind Job
+  job: "batch/v1"
+  
 # -- OpenShift API versions for OpenShift kinds
 openShiftKindAPIVersions:
   # -- OpenShift API version for kind Route

--- a/values.yaml
+++ b/values.yaml
@@ -225,10 +225,22 @@ deployment:
     aws:
       enabled: false
       secretManager:
+        # -- Secret Injector container image configuration
+        image:
+          # -- Container image registry host name
+          registry: ""
+          # -- Container image repository name
+          repository: ""
+          # -- Container image tag
+          tag: ""
+          # -- Container image digest
+          digest: ""
         # -- AWS Secret Manager secret name of the internal keystore password
         secretName: "INTERNAL-KEYSTORE-PASSWORD-DECRYPTED"
         # -- Region of the deployment
         region: ""
+        # -- Output path for the secret
+        outputPath: "/tmp/password-tmp"
   configMaps:
     entryPoint:
       defaultMode: "0407"

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -36,7 +36,7 @@ deployment:
     tlsSecretsName: "is-tls"
     # -- Enable Nginx rate limiting
     enableNginxRateLimit: false
-    annotations:
+    commonAnnotations: &commonAnnotations
       nginx.ingress.kubernetes.io/affinity: "cookie"
       nginx.ingress.kubernetes.io/session-cookie-name: "paf"
       nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
@@ -45,12 +45,23 @@ deployment:
       nginx.ingress.kubernetes.io/session-cookie-conditional-samesite-none: "true"
       nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
       nginx.ingress.kubernetes.io/session-cookie-path: "/"
-      nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
       # Enable or disable proxy buffering proxy_buffering. By default, proxy buffering is disabled in the NGINX config(Ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#proxy-buffering).
       nginx.ingress.kubernetes.io/proxy-buffering: "on"
       # Sets the size of the buffer proxy_buffer_size used for reading the first part of the response received from the proxied server. By default proxy buffer size is set as "64k".(Ref: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#proxy-buffer-size)
       nginx.ingress.kubernetes.io/proxy-buffer-size: "64k"
-
+    azure:
+      enabled: false
+      annotations:
+        !!merge <<: *commonAnnotations
+        nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    aws:
+      enabled: false
+      annotations:
+        !!merge <<: *commonAnnotations
+        nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+  rbac:
+    annotations:
+      eks.amazonaws.com/role-arn: "null"
   image:
     # -- Container image registry host name
     registry: "docker.wso2.com"
@@ -175,7 +186,7 @@ deployment:
       userstores: "userstores"
     azure:
       # -- Enable persistence for artifact sharing using Azure file share
-      enabled: true
+      enabled: false
       # -- Azure Storage Account credentials to access the file shares
       # -- Ref: https://docs.microsoft.com/en-us/azure/aks/azure-files-volume#create-a-kubernetes-secret
       # -- Names of Azure File shares for persisted data
@@ -184,12 +195,17 @@ deployment:
       secretName: "azure-storage-csi"
     # -- Define capacity for persistent runtime artifacts which are shared between instances of the Identity Server profile
     capacity: 100Gi
+    aws:
+      # -- Enable persistence for artifact sharing using AWS EFS
+      enabled: false
+      # -- EFS volume handle ID
+      volumeHandle: ""
   secretStore:
     # -- Enable secure vault with secret store CSI driver
     enabled: false
     azure:
       # -- Enable Azure Key Vault integration.
-      enabled: true
+      enabled: false
       keyVault:
         # -- Name of the target Azure Key Vault instance
         name: ""
@@ -206,6 +222,13 @@ deployment:
         secretName: "INTERNAL-KEYSTORE-PASSWORD-DECRYPTED"
       # -- The name of the Kubernetes secret that contains the service principal credentials to access Azure Key Vault. Ref: https://azure.github.io/secrets-store-csi-driver-provider-azure/docs/configurations/identity-access-modes/service-principal-mode/#configure-service-principal-to-access-keyvault
       nodePublishSecretRef: "azure-kv-secret-store-sp"
+    aws:
+      enabled: false
+      secretManager:
+        # -- AWS Secret Manager secret name of the internal keystore password
+        secretName: "INTERNAL-KEYSTORE-PASSWORD-DECRYPTED"
+        # -- Region of the deployment
+        region: ""
   configMaps:
     entryPoint:
       defaultMode: "0407"
@@ -491,3 +514,5 @@ k8sKindAPIVersions:
   secret: "v1"
   # -- K8s API version for kind Service
   service: "v1"
+  # -- k8s API verion for CSI Driver
+  csi: "storage.k8s.io/v1"


### PR DESCRIPTION
# Add AWS Compatibility for Helm Deployment

## Purpose
Enable WSO2 Identity Server deployment via Helm to support AWS environment.

## Changes Made
- **`confs/secret-conf.properties`**: Added configuration to fetch secrets from AWS Secrets Manager using Kubernetes service account.
- **`templates/cm-entrypoint.yaml`**: Added internal keystore decrypted password path for AWS.
- **`templates/deployment.yaml`**: Added init container to fetch decrypted keystore password from AWS Secrets Manager.
- **`templates/pvc-wait-hook-job.yaml`**: Added pre-install hook to wait for PVC to be bound.
