### PR TITLE
Increase pod request and limit value for cpu and memory

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -153,14 +153,14 @@ deployment:
     # -- as per official documentation (Ref: https://is.docs.wso2.com/en/latest/setup/installation-prerequisites/)
     requests:
       # -- The minimum amount of memory that should be allocated for a Pod
-      memory: "2Gi"
+      memory: "4Gi"
       # -- The minimum amount of CPU that should be allocated for a Pod
-      cpu: "2"
+      cpu: "4"
     limits:
       # -- The maximum amount of memory that should be allocated for a Pod
-      memory: "4Gi"
+      memory: "8Gi"
       # -- The maximum amount of CPU that should be allocated for a Pod
-      cpu: "3"
+      cpu: "6"
     jvm:
       # -- JVM memory options
       memOpts: "-Xms2048m -Xmx2048m"


### PR DESCRIPTION
### Purpose ###
This pull request updates resource allocation settings in the `values.yaml` file to increase memory and CPU requests and limits for deployment pods.

Resource allocation updates:

* Increased the minimum memory request from `2Gi` to `4Gi` and the minimum CPU request from `2` to `4`. (`[values.yamlL156-R163](diffhunk://#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7eL156-R163)`)
* Increased the maximum memory limit from `4Gi` to `8Gi` and the maximum CPU limit from `3` to `6`. (`[values.yamlL156-R163](diffhunk://#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7eL156-R163)`)