### PR TITLE
Remove AppArmor Pod Annotations From Identity Server Deployment

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -43,9 +43,6 @@ spec:
         checksum.log4j.properties: {{ include (print $.Template.BasePath "/cm-log4j2-properties.yaml") . | sha256sum }}
         checksum.entrypoint.sh: {{ include (print $.Template.BasePath "/cm-entrypoint.yaml") . | sha256sum }}
         checksum.thrift-authentication.xml: {{ include (print $.Template.BasePath "/cm-thrift-authentication-xml.yaml") . | sha256sum }}
-        {{- if .Values.deployment.apparmor.enabled }}
-        container.apparmor.security.beta.kubernetes.io/wso2is: {{ .Values.deployment.apparmor.profile }}
-        {{- end }}
         {{- if .Values.deployment.secretStore.aws.enabled }}
         secret.k8s.aws/secret-name: {{ .Values.deployment.secretStore.aws.secretManager.secretName }}
         secret.k8s.aws/region: {{ .Values.deployment.secretStore.aws.secretManager.region }}


### PR DESCRIPTION
## Purpose
This pull request updates the AppArmor configuration in the Identity Server Helm chart by migrating from a pod annotation-based approach to a container-level security context.

- The AppArmor pod annotations were reintroduced in the current PR despite being removed in a previous commit ([67a72a7](https://github.com/wso2/kubernetes-is/commit/67a72a7fdd6c0e642d22bd403d0743215e1415ac))
- This PR removes these annotations to maintain consistency and align with container-level security best practices.
- Resolves inconsistencies introduced in ([PR #335](https://github.com/wso2/kubernetes-is/pull/335/files#diff-7792a5fea7287a039634c3c2ee77f1b23d7fcd8b8f6e225446a9e5456dd77a38))

Newer Kubernetes versions (1.30+) prefer using the **securityContext.appArmorProfile** field over pod annotations. Removing the pod-level AppArmor annotation prevents conflicts between annotation and container-level settings, ensures compatibility with modern Kubernetes versions, and avoids deployment errors such as invalid profile names or forbidden AppArmor type mismatches.

## Approach
Remove pod-level AppArmor annotations from the deployment YAML.
~~~
container.apparmor.security.beta.kubernetes.io/wso2is: {{ .Values.deployment.apparmor.profile }}
~~~

## Related PRs

- [PR #335](https://github.com/wso2/kubernetes-is/pull/335/files#diff-7792a5fea7287a039634c3c2ee77f1b23d7fcd8b8f6e225446a9e5456dd77a38) – Previous PR that reintroduced pod annotations
- [Commit 67a72a7](https://github.com/wso2/kubernetes-is/commit/67a72a7fdd6c0e642d22bd403d0743215e1415ac) – Original removal of annotations