### PR TITLE
Fix imagePullSecret reference in deployment.yaml

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -236,7 +236,7 @@ spec:
       serviceAccountName: {{ template "..fullname" . }}
       {{- if .Values.deployment.image.imagePullSecret }}
       imagePullSecrets:
-        - name: {{ .Values.wso2.deployment.image.imagePullSecret }}
+        - name: {{ .Values.deployment.image.imagePullSecret }}
       {{- else if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
       imagePullSecrets:
         - name: {{ template "..fullname" . }}-wso2-private-registry-creds


### PR DESCRIPTION
## Purpose

Currently, the if-condition checks against `.Values.deployment.image.imagePullSecret`; however, if it exists, it uses the value from `.Values.wso2.deployment.image.imagePullSecret`, which is not appropriate.

This causes an error when I am trying to deploy:
> nil pointer evaluating interface {}.image

It means that Helm cannot find the deployment block in my values.

## Goals

Fixes the issue where it is referencing the wrong block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the image pull secret configuration reference path in deployment settings to align with the revised values configuration structure for improved consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->