### PR TITLE
Commenting dangling logger references

### DIFF
--- a/confs/log4j2.properties
+++ b/confs/log4j2.properties
@@ -138,10 +138,10 @@ logger.org-apache-axis2-clustering.name = org.apache.axis2.clustering
 logger.org-apache-axis2-clustering.level = INFO
 logger.org-apache-axis2-clustering.additivity = false
 
-logger.org-apache.name = org.apache
-logger.org-apache.level = INFO
-logger.org-apache.additivity = false
-logger.org-apache.appenderRef.CARBON_CONSOLE.ref = CARBON_CONSOLE
+#logger.org-apache.name = org.apache
+#logger.org-apache.level = INFO
+#logger.org-apache.additivity = false
+#logger.org-apache.appenderRef.CARBON_CONSOLE.ref = CARBON_CONSOLE
 
 logger.org-apache-catalina.name = org.apache.catalina
 logger.org-apache-catalina.level = ERROR
@@ -202,8 +202,8 @@ logger.org-apache-solr.level = ERROR
 logger.me-prettyprint-cassandra-hector-TimingLogger.name = me.prettyprint.cassandra.hector.TimingLogger
 logger.me-prettyprint-cassandra-hector-TimingLogger.level = ERROR
 
-logger.org-wso2.name = org.wso2
-logger.org-wso2.level = ERROR
+#logger.org-wso2.name = org.wso2
+#logger.org-wso2.level = ERROR
 
 logger.org-apache-axis-enterprise.name = org.apache.axis2.enterprise
 logger.org-apache-axis-enterprise.level = FATAL
@@ -242,10 +242,10 @@ logger.org-apache-directory-server-ldap-LdapSession.name = org.apache.directory.
 logger.org-apache-directory-server-ldap-LdapSession.level = Error
 logger.org-apache-directory-server-ldap-LdapSession.appenderRef.CARBON_CONSOLE.ref = CARBON_CONSOLE
 
-logger.correlation.name = correlation
-logger.correlation.level = INFO
-logger.correlation.appenderRef.CORRELATION_CONSOLE.ref = CORRELATION_CONSOLE
-logger.correlation.additivity = false
+#logger.correlation.name = correlation
+#logger.correlation.level = INFO
+#logger.correlation.appenderRef.CORRELATION_CONSOLE.ref = CORRELATION_CONSOLE
+#logger.correlation.additivity = false
 
 logger.diagnostics.name = diagnostics
 logger.diagnostics.level = INFO
@@ -352,8 +352,8 @@ logger.org-wso2-carbon-identity-oauth2.level=INFO
 logger.org-wso2-carbon-identity-oauth.name=org.wso2.carbon.identity.oauth
 logger.org-wso2-carbon-identity-oauth.level=INFO
 
-logger.org-wso2-carbon-identity-oidc.name=org.wso2.carbon.identity.oidc
-logger.org-wso2-carbon-identity-oidc.level=INFO
+#logger.org-wso2-carbon-identity-oidc.name=org.wso2.carbon.identity.oidc
+#logger.org-wso2-carbon-identity-oidc.level=INFO
 
 logger.org-wso2-carbon-identity-application-authenticator.name=org.wso2.carbon.identity.application.authenticator
 logger.org-wso2-carbon-identity-application-authenticator.level=INFO


### PR DESCRIPTION
## Purpose
> $subject

Commenting the dangling references in the log4j2.properties files as there is a new validation enforced with the log4j2 2.25.3 version for the appenders and loggers array in the file. Going forward all the references should be registered in the respective arrays.

## Related issue
- https://github.com/wso2/product-is/issues/26754
