### PR TITLE
Add support for additional pod labels, annotations, and node selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ helm install "$RELEASE_NAME" wso2/identity-server --version 7.2.0-1  -n "$NAMESP
 | deployment.ingress.tlsSecretsName | string | `"is-tls"` | K8s TLS secret for configured hostname |
 | deployment.livenessProbe | object | `{"periodSeconds":10}` | Indicates whether the container is running |
 | deployment.livenessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the probe |
+| deployment.nodeSelector | object | `{}` | Node selector to deploy pod in a selected node. Add a label to the node and specify the label here. |
 | deployment.pdb.minAvailable | string | `"50%"` | Minimum availability for PDB |
 | deployment.persistence.azure.enabled | bool | `true` | Enable persistence for artifact sharing using Azure file share |
 | deployment.persistence.azure.fileShare | string | `"is-share"` | Names of Azure File shares for persisted data |
@@ -512,6 +513,8 @@ helm install "$RELEASE_NAME" wso2/identity-server --version 7.2.0-1  -n "$NAMESP
 | deployment.persistence.enabled | bool | `false` | Enable persistence for artifact sharing |
 | deployment.persistence.subPaths.tenants | string | `"tenants"` | Azure storage account tenants file share path |
 | deployment.persistence.subPaths.userstores | string | `"userstores"` | Azure storage account userstores file share path |
+| deployment.podAnnotations | object | `{}` | Additional pod annotations |
+| deployment.podLabels | object | `{}` | Additional pod labels |
 | deployment.preStopHookWaitSeconds | int | `10` | preStopHookWaitInSeconds waits before calling server stop in the pre stop hook. |
 | deployment.productPackName | string | `"wso2is"` | Product pack name |
 | deployment.progressDeadlineSeconds | int | `600` | Progress deadline seconds where the Deployment controller waits before indicating (in the Deployment status) that the Deployment progress has stalled. |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -34,11 +34,14 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "..selectorLabels" . | nindent 8 }}
         {{- if .Values.deployment.podLabels }}
         {{- toYaml .Values.deployment.podLabels | nindent 8 }}
         {{- end }}
+        {{- include "..selectorLabels" . | nindent 8 }}
       annotations:
+        {{- if .Values.deployment.podAnnotations }}
+        {{- toYaml .Values.deployment.podAnnotations | nindent 8 }}
+        {{- end }}
         checksum.deployment.toml: {{ include (print $.Template.BasePath "/cm-deployment-toml.yaml") . | sha256sum }}
         {{- if .Values.deployment.secretStore.enabled  }}
         checksum.secret.properties: {{ include (print $.Template.BasePath "/cm-secret-config-properties.yaml") . | sha256sum }}
@@ -50,9 +53,6 @@ spec:
         secret.k8s.aws/secret-name: {{ .Values.deployment.secretStore.aws.secretManager.secretName }}
         secret.k8s.aws/region: {{ .Values.deployment.secretStore.aws.secretManager.region }}
         secret.k8s.aws/output-path: {{ .Values.deployment.secretStore.aws.secretManager.outputPath }}
-        {{- end }}
-        {{- if .Values.deployment.podAnnotations }}
-        {{- toYaml .Values.deployment.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
       securityContext:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
     metadata:
       labels:
         {{- include "..selectorLabels" . | nindent 8 }}
+        {{- if .Values.deployment.podLabels }}
+        {{- toYaml .Values.deployment.podLabels | nindent 8 }}
+        {{- end }}
       annotations:
         checksum.deployment.toml: {{ include (print $.Template.BasePath "/cm-deployment-toml.yaml") . | sha256sum }}
         {{- if .Values.deployment.secretStore.enabled  }}
@@ -47,6 +50,9 @@ spec:
         secret.k8s.aws/secret-name: {{ .Values.deployment.secretStore.aws.secretManager.secretName }}
         secret.k8s.aws/region: {{ .Values.deployment.secretStore.aws.secretManager.region }}
         secret.k8s.aws/output-path: {{ .Values.deployment.secretStore.aws.secretManager.outputPath }}
+        {{- end }}
+        {{- if .Values.deployment.podAnnotations }}
+        {{- toYaml .Values.deployment.podAnnotations | nindent 8 }}
         {{- end }}
     spec:
       securityContext:
@@ -74,6 +80,10 @@ spec:
                       values:
                         - {{ .Release.Name }}
                 topologyKey: topology.kubernetes.io/zone
+      {{- if .Values.deployment.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
+      {{- end }}
       {{- if .Values.deployment.secretStore.aws.enabled }}
       initContainers:
         - name: aws-secrets-injector

--- a/values.yaml
+++ b/values.yaml
@@ -97,6 +97,12 @@ deployment:
   #      # Provide the name of the ConfigMap containing the files you want
   #      # to add to the container
   #      name: custom-property-file
+  # -- Additional pod labels
+  podLabels: {}
+  # -- Additional pod annotations
+  podAnnotations: {}
+  # -- Node selector to deploy pod in selected node. Add label to the node and specify the label here.
+  nodeSelector: {}
   securityContext:
     # -- Run as user ID
     runAsUser: 802


### PR DESCRIPTION
This pull request enhances the configurability of Kubernetes deployments by allowing users to specify additional pod labels, annotations, and node selectors via Helm values. These changes make it easier to customize deployments without modifying the template directly.

**Helm chart configurability improvements:**

* Added support for specifying extra pod labels using the `deployment.podLabels` value in `values.yaml` and rendering them in the deployment template. [[1]](diffhunk://#diff-7792a5fea7287a039634c3c2ee77f1b23d7fcd8b8f6e225446a9e5456dd77a38R38-R40) [[2]](diffhunk://#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7eR100-R105)
* Added support for specifying extra pod annotations using the `deployment.podAnnotations` value in `values.yaml` and rendering them in the deployment template. [[1]](diffhunk://#diff-7792a5fea7287a039634c3c2ee77f1b23d7fcd8b8f6e225446a9e5456dd77a38R54-R56) [[2]](diffhunk://#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7eR100-R105)
* Added support for specifying a node selector using the `deployment.nodeSelector` value in `values.yaml` and rendering it in the deployment template. [[1]](diffhunk://#diff-7792a5fea7287a039634c3c2ee77f1b23d7fcd8b8f6e225446a9e5456dd77a38R83-R86) [[2]](diffhunk://#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7eR100-R105)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pod labels, annotations, and node selector configuration now supported for deployments, enabling fine-grained control over pod metadata and scheduling constraints through simple configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->