### PR TITLE
Add configuration to enable/disable authorizeAllScopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,7 @@ helm install "$RELEASE_NAME" wso2/identity-server --version 7.2.0-1  -n "$NAMESP
 | deploymentToml.keystore.tls.keyPassword | string | `"wso2carbon"` |  |
 | deploymentToml.keystore.tls.password | string | `"wso2carbon"` |  |
 | deploymentToml.keystore.tls.type | string | `"PKCS12"` |  |
+| deploymentToml.oauth.authorizeAllScopes | bool | `false` | Enable/Disable the scope authorization for all the OAuth clients. Ref: https://apim.docs.wso2.com/en/latest/api-security/key-management/third-party-key-managers/configure-wso2is7-connector/ |
 | deploymentToml.oauth.tokenCleanup | bool | `false` | Enable/Disable the internal token cleanup process. Ref: https://is.docs.wso2.com/en/6.0.0/deploy/remove-unused-tokens-from-the-database/#! |
 | deploymentToml.oauth.tokenGeneration.includeUsernameInAccessToken | bool | `false` | Add UserName Assertions in Access Tokens. Ref: https://is.docs.wso2.com/en/6.0.0/deploy/enable-assertions-in-access-tokens/ |
 | deploymentToml.otp.email.addressRequestPage | string | `"https://localhost:9443/emailotpauthenticationendpoint/emailAddress.jsp"` |  |

--- a/confs/deployment.toml
+++ b/confs/deployment.toml
@@ -216,6 +216,11 @@ properties.KUBERNETES_NAMESPACE={{ .Release.Namespace | quote }}
 properties.KUBERNETES_SERVICES={{ include "..fullname" . | quote }}
 {{- end }}
 
+{{- if .Values.deploymentToml.oauth.authorizeAllScopes }}
+[oauth]
+authorize_all_scopes = {{.Values.deploymentToml.oauth.authorizeAllScopes }}
+{{- end }}
+
 [oauth.token_cleanup]
 enable = {{.Values.deploymentToml.oauth.tokenCleanup }}
 

--- a/values.yaml
+++ b/values.yaml
@@ -432,6 +432,8 @@ deploymentToml:
      enableStartTls: true
      enableAuthentication: true
   oauth:
+    # -- Enable/Disable the scope authorization for all the OAuth clients. Ref: https://apim.docs.wso2.com/en/latest/api-security/key-management/third-party-key-managers/configure-wso2is7-connector/
+    authorizeAllScopes: false
     # -- Enable/Disable the internal token cleanup process. Ref: https://is.docs.wso2.com/en/6.0.0/deploy/remove-unused-tokens-from-the-database/#!
     tokenCleanup: false
     tokenGeneration:


### PR DESCRIPTION
## Purpose
> 
This pull request introduces a new configuration option to enable or disable scope authorization for all OAuth clients in WSO2 Identity Server deployments via Helm. The change adds the `authorizeAllScopes` parameter, allowing users to control this behavior through Helm values, the deployment template, and documentation.

New OAuth configuration option:

* [`values.yaml`](diffhunk://#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7eR435-R436): Added the `deploymentToml.oauth.authorizeAllScopes` parameter with a default value of `false` to allow enabling/disabling scope authorization for all OAuth clients.
* [`confs/deployment.toml`](diffhunk://#diff-d7d3b8da433ee06f7658f0caef68c2d6b2633a4ec10f25f2b68670a9c220f0f1R219-R223): Updated the deployment template to conditionally include the `[oauth] authorize_all_scopes` setting based on the new parameter.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R608): Documented the new `deploymentToml.oauth.authorizeAllScopes` parameter, including a reference link for further information.