### PR TITLE
Add support for pod labels, annotations, and node selectors in deploy…

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ helm install "$RELEASE_NAME" wso2/identity-server --version 7.2.0-1  -n "$NAMESP
 | deployment.ingress.tlsSecretsName | string | `"is-tls"` | K8s TLS secret for configured hostname |
 | deployment.livenessProbe | object | `{"periodSeconds":10}` | Indicates whether the container is running |
 | deployment.livenessProbe.periodSeconds | int | `10` | How often (in seconds) to perform the probe |
+| deployment.nodeSelector | object | `{}` | Node selector to deploy pod in a selected node. Add a label to the node and specify the label here. |
 | deployment.pdb.minAvailable | string | `"50%"` | Minimum availability for PDB |
 | deployment.persistence.azure.enabled | bool | `true` | Enable persistence for artifact sharing using Azure file share |
 | deployment.persistence.azure.fileShare | string | `"is-share"` | Names of Azure File shares for persisted data |
@@ -512,6 +513,8 @@ helm install "$RELEASE_NAME" wso2/identity-server --version 7.2.0-1  -n "$NAMESP
 | deployment.persistence.enabled | bool | `false` | Enable persistence for artifact sharing |
 | deployment.persistence.subPaths.tenants | string | `"tenants"` | Azure storage account tenants file share path |
 | deployment.persistence.subPaths.userstores | string | `"userstores"` | Azure storage account userstores file share path |
+| deployment.podAnnotations | object | `{}` | Additional pod annotations |
+| deployment.podLabels | object | `{}` | Additional pod labels |
 | deployment.preStopHookWaitSeconds | int | `10` | preStopHookWaitInSeconds waits before calling server stop in the pre stop hook. |
 | deployment.productPackName | string | `"wso2is"` | Product pack name |
 | deployment.progressDeadlineSeconds | int | `600` | Progress deadline seconds where the Deployment controller waits before indicating (in the Deployment status) that the Deployment progress has stalled. |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -34,8 +34,14 @@ spec:
   template:
     metadata:
       labels:
+        {{- if .Values.deployment.podLabels }}
+        {{- toYaml .Values.deployment.podLabels | nindent 8 }}
+        {{- end }}
         {{- include "..selectorLabels" . | nindent 8 }}
       annotations:
+        {{- if .Values.deployment.podAnnotations }}
+        {{- toYaml .Values.deployment.podAnnotations | nindent 8 }}
+        {{- end }}
         checksum.deployment.toml: {{ include (print $.Template.BasePath "/cm-deployment-toml.yaml") . | sha256sum }}
         {{- if .Values.deployment.secretStore.enabled  }}
         checksum.secret.properties: {{ include (print $.Template.BasePath "/cm-secret-config-properties.yaml") . | sha256sum }}
@@ -74,6 +80,10 @@ spec:
                       values:
                         - {{ .Release.Name }}
                 topologyKey: topology.kubernetes.io/zone
+      {{- if .Values.deployment.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
+      {{- end }}
       {{- if .Values.deployment.secretStore.aws.enabled }}
       initContainers:
         - name: aws-secrets-injector

--- a/values.yaml
+++ b/values.yaml
@@ -97,6 +97,12 @@ deployment:
   #      # Provide the name of the ConfigMap containing the files you want
   #      # to add to the container
   #      name: custom-property-file
+  # -- Additional pod labels
+  podLabels: {}
+  # -- Additional pod annotations
+  podAnnotations: {}
+  # -- Node selector to deploy pod in selected node. Add label to the node and specify the label here.
+  nodeSelector: {}
   securityContext:
     # -- Run as user ID
     runAsUser: 802


### PR DESCRIPTION
This pull request adds new configuration options to enhance the flexibility and control of Kubernetes deployments for the WSO2 Identity Server Helm chart. The changes introduce support for custom pod labels, annotations, and node selection, allowing users to better tailor deployments to their infrastructure and operational requirements.

**Key enhancements:**

**Pod customization:**

* Added support for specifying additional pod labels and annotations via `deployment.podLabels` and `deployment.podAnnotations` in `values.yaml`, and updated the deployment template to apply these values to pod metadata. [[1]](diffhunk://#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7eR100-R105) [[2]](diffhunk://#diff-7792a5fea7287a039634c3c2ee77f1b23d7fcd8b8f6e225446a9e5456dd77a38R37-R44)
* Documented the new `deployment.podLabels` and `deployment.podAnnotations` options in `README.md`.

**Node scheduling:**

* Introduced a `deployment.nodeSelector` configuration in `values.yaml` and updated the deployment template to support scheduling pods on specific nodes with matching labels. [[1]](diffhunk://#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7eR100-R105) [[2]](diffhunk://#diff-7792a5fea7287a039634c3c2ee77f1b23d7fcd8b8f6e225446a9e5456dd77a38R83-R86)
* Documented the `deployment.nodeSelector` option in `README.md`.

### Related PRs
- https://github.com/wso2/kubernetes-is/pull/358