### PR TITLE
[master] Update registry reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,32 @@ ___
 ### Security
 - AppArmor Security Module enabled
 
+### WSO2 Registry Access (for WSO2 Support users)
+
+If you are using WSO2 Support images from the WSO2 Container Registry (`registry.wso2.com`), you must authenticate using a registry token — WSO2 account credentials can no longer be used directly for CLI access.
+
+**Generate a Token:**
+1. Log in to the [WSO2 Support Portal](https://support.wso2.com).
+2. Navigate to **Projects > My Projects > Registry Tokens**.
+3. Click **Generate Token** and provide a descriptive name (e.g., `k8s-deployment-token`).
+4. **Important:** Copy the **Token ID** and **Token Secret** immediately — the secret is shown only once.
+
+For more details, refer to the [WSO2 Registry CLI Access documentation](https://updates.docs.wso2.com/en/latest/updates/wso2-registry-cli-access/).
+
+**Log in to the WSO2 Registry:**
+```shell
+docker login registry.wso2.com -u <Token_ID> -p <Token_Secret>
+```
+
+**Create a Kubernetes image pull secret** so that your cluster can pull images from the registry:
+```shell
+kubectl create secret docker-registry wso2-registry-credentials \
+  --docker-server=registry.wso2.com \
+  --docker-username=<Token_ID> \
+  --docker-password=<Token_Secret> \
+  -n $NAMESPACE
+```
+
 ### Tools
 | Tool          | Installation Guide | Version Check Command |
 |---------------|--------------------|-----------------------|
@@ -90,6 +116,12 @@ There are two ways to install the WSO2 Identity Server using the Helm chart.
 
     **Note:** To disable AppArmor, set --set deployment.apparmor.enabled="false" (default: true)
 
+    > **WSO2 Support users:** If you are using images from the WSO2 Container Registry (`registry.wso2.com`) with WSO2 Support, you must authenticate using a registry token. See [Accessing Images via CLI](https://updates.docs.wso2.com/en/latest/updates/wso2-registry-cli-access/) for instructions on generating a token and creating an image pull secret. Then add the following to the install command:
+    > ```shell
+    > --set deployment.image.registry="registry.wso2.com" \
+    > --set deployment.image.imagePullSecret="wso2-registry-credentials"
+    > ```
+
 ### Option 2: Install the Chart from source
 
 If you prefer to build the chart from the source, follow the steps below:
@@ -113,6 +145,12 @@ If you prefer to build the chart from the source, follow the steps below:
     **Note:** 
     - To disable AppArmor, set --set deployment.apparmor.enabled="false" (default: true)
     - The above commands use the publicly released [WSO2 Identity Server Docker image](https://hub.docker.com/r/wso2/wso2is). To use a custom docker image, update the registry, repository, and tag accordingly. You can also specify an image digest instead of a tag as shown below:
+
+    > **WSO2 Support users:** If you are using images from the WSO2 Container Registry (`registry.wso2.com`) with WSO2 Support, you must authenticate using a registry token. See [Accessing Images via CLI](https://updates.docs.wso2.com/en/latest/updates/wso2-registry-cli-access/) for instructions on generating a token and creating an image pull secret. Then add the following to the install command:
+    > ```shell
+    > --set deployment.image.registry="registry.wso2.com" \
+    > --set deployment.image.imagePullSecret="wso2-registry-credentials"
+    > ```
     
         ```shell
         --set deployment.image.digest=<digest> 
@@ -485,8 +523,8 @@ helm install "$RELEASE_NAME" wso2/identity-server --version 7.2.0-1  -n "$NAMESP
 | deployment.image.digest | string | `""` | Container image digest |
 | deployment.image.imagePullSecret | string | `""` | image pull secret name |
 | deployment.image.pullPolicy | string | `"Always"` | Refer to the Kubernetes documentation on updating images (Ref: https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
-| deployment.image.registry | string | `"docker.wso2.com"` | Container image registry host name |
-| deployment.image.repository | string | `"wso2is"` | Container image repository name |
+| deployment.image.registry | string | `"registry.wso2.com"` | Container image registry host name |
+| deployment.image.repository | string | `"wso2-is/is"` | Container image repository name |
 | deployment.image.tag | string | `"7.2.0"` | Container image tag. Either "tag" or "digest" should defined |
 | deployment.ingress.annotations."nginx.ingress.kubernetes.io/affinity" | string | `"cookie"` |  |
 | deployment.ingress.annotations."nginx.ingress.kubernetes.io/backend-protocol" | string | `"HTTPS"` |  |

--- a/templates/secret-image-pull.yaml
+++ b/templates/secret-image-pull.yaml
@@ -1,5 +1,5 @@
 {{ if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2024-2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -18,7 +18,7 @@
 {{- $username := .Values.wso2.subscription.username }}
 {{- $password := .Values.wso2.subscription.password }}
 {{- $email := .Values.wso2.subscription.username }}
-{{- $regId := "docker.wso2.com" }}
+{{- $regId := "registry.wso2.com" }}
 {{- $auth := printf "%s:%s" $username $password | b64enc }}
 {{- $files := .Files }}
 

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -85,7 +85,7 @@ deployment:
   # -- Number of deployment replicas
   replicas: 1
   # -- Additional volumeMounts to the pods. All the configuration mounts should be done under the path "/home/wso2carbon/wso2-config-volume/"
-  extraVolumeMounts: []
+  extraVolumeMounts: [ ]
   #  - name: custom-property-file
   #    mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/custom-property-file.properties
   #    subPath: custom-property-file.properties
@@ -106,7 +106,7 @@ deployment:
     enableRunAsGroup: false
     seccompProfile:
       enabled: true
-      # --  Seccomp profile type
+    # --  Seccomp profile type
       type: "RuntimeDefault"
     seLinux:
       enabled: false
@@ -165,11 +165,9 @@ deployment:
       # -- JVM memory options
       memOpts: "-Xms2048m -Xmx2048m"
       # -- JVM parameters
-      javaOpts: -Djdk.tls.ephemeralDHKeySize=2048
-        -Djdk.tls.rejectClientInitiatedRenegotiation=true
+      javaOpts: -Djdk.tls.ephemeralDHKeySize=2048 -Djdk.tls.rejectClientInitiatedRenegotiation=true
         -Dhttpclient.hostnameVerifier=Strict -Djdk.tls.client.protocols=TLSv1.2
-        -Djava.util.prefs.systemRoot=/home/wso2carbon/.java
-        -Djava.util.prefs.userRoot=/home/wso2carbon/.java/.userPrefs
+        -Djava.util.prefs.systemRoot=/home/wso2carbon/.java -Djava.util.prefs.userRoot=/home/wso2carbon/.java/.userPrefs
   # -- Product version
   buildVersion: "7.2.0"
   # -- Product pack name
@@ -302,101 +300,96 @@ deploymentToml:
       # -- The database username
       username: "wso2carbon"
       # -- The database JDBC URL
-      url: "jdbc:h2:./repository/database/WSO2IDENTITY_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK\
-        _TIMEOUT=60000"
+      url: "jdbc:h2:./repository/database/WSO2IDENTITY_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
       # -- The password
       password: "wso2carbon"
       # -- The database JDBC driver
       driver: "org.h2.Driver"
       # -- The database pool options
       poolOptions:
-        #        maxActive: "50"
-        #        maxWait: "60000"
-        #        minIdle: "10"
-        #        validationInterval: "30000"
-        #        defaultAutoCommit: true
-        #        commitOnReturn: false
+#        maxActive: "50"
+#        maxWait: "60000"
+#        minIdle: "10"
+#        validationInterval: "30000"
+#        defaultAutoCommit: true
+#        commitOnReturn: false
     shared:
       # -- The SQL server type(ex: mysql, mssql)
       type: "h2"
       # -- The database username
       username: "wso2carbon"
       # -- The database JDBC URL
-      url: "jdbc:h2:./repository/database/WSO2SHARED_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_T\
-        IMEOUT=60000"
+      url: "jdbc:h2:./repository/database/WSO2SHARED_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
       # -- The database password
       password: "wso2carbon"
       # -- The database JDBC driver
       driver: "org.h2.Driver"
       # -- The database pool options
       poolOptions:
-        #          maxActive: "50"
-        #          maxWait: "60000"
-        #          minIdle: "10"
-        #          validationInterval: "30000"
-        #          defaultAutoCommit: true
-        #          commitOnReturn: false
+#          maxActive: "50"
+#          maxWait: "60000"
+#          minIdle: "10"
+#          validationInterval: "30000"
+#          defaultAutoCommit: true
+#          commitOnReturn: false
     user:
       # -- The SQL server type(ex: mysql, mssql)
       type: "h2"
       # -- The database username
       username: "wso2carbon"
       # -- The database JDBC URL
-      url: "jdbc:h2:./repository/database/WSO2SHARED_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_T\
-        IMEOUT=60000"
+      url: "jdbc:h2:./repository/database/WSO2SHARED_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
       # -- The database password
       password: "wso2carbon"
       # -- The database JDBC driver
       driver: "org.h2.Driver"
       # -- The database pool options
       poolOptions:
-        #          maxActive: "50"
-        #          maxWait: "60000"
-        #          minIdle: "10"
-        #          validationInterval: "30000"
-        #          defaultAutoCommit: true
-        #          commitOnReturn: false
+#          maxActive: "50"
+#          maxWait: "60000"
+#          minIdle: "10"
+#          validationInterval: "30000"
+#          defaultAutoCommit: true
+#          commitOnReturn: false
     consent:
       # -- The SQL server type(ex: mysql, mssql)
       type: "h2"
       # -- The database username
       username: "wso2carbon"
       # -- The database JDBC URL
-      url: "jdbc:h2:./repository/database/WSO2IDENTITY_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK\
-        _TIMEOUT=60000"
+      url: "jdbc:h2:./repository/database/WSO2IDENTITY_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
       # -- The database password
       password: "wso2carbon"
       # -- The database JDBC driver
       driver: "org.h2.Driver"
       # -- The database pool options
       poolOptions:
-        #        maxActive: "80"
-        #        maxWait: "60000"
-        #        minIdle: "5"
-        #        testOnBorrow: true
-        #        validationQuery: "SELECT 1"
-        #        validationInterval: "30000"
-        #        defaultAutoCommit: false
+#        maxActive: "80"
+#        maxWait: "60000"
+#        minIdle: "5"
+#        testOnBorrow: true
+#        validationQuery: "SELECT 1"
+#        validationInterval: "30000"
+#        defaultAutoCommit: false
     agentIdentity:
       # -- The SQL server type(ex: mysql, mssql)
       type: "h2"
       # -- The database username
       username: "wso2carbon"
       # -- The database JDBC URL
-      url: "jdbc:h2:./repository/database/WSO2AGENTIDENTITY_DB;DB_CLOSE_ON_EXIT=FALSE\
-        ;LOCK_TIMEOUT=60000"
+      url: "jdbc:h2:./repository/database/WSO2AGENTIDENTITY_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
       # -- The database password
       password: "wso2carbon"
       # -- The database JDBC driver
       driver: "org.h2.Driver"
       # -- The database pool options
       poolOptions:
-        #        maxActive: "50"
-        #        maxWait: "60000"
-        #        minIdle: "10"
-        #        validationInterval: "30000"
-        #        defaultAutoCommit: true
-        #        commitOnReturn: false
+#        maxActive: "50"
+#        maxWait: "60000"
+#        minIdle: "10"
+#        validationInterval: "30000"
+#        defaultAutoCommit: true
+#        commitOnReturn: false
   keystore:
     tls:
       fileName: "wso2carbon.p12"
@@ -429,15 +422,15 @@ deploymentToml:
     secretKey: ""
   outputAdapter:
     email:
-      # -- Enable the email sender. Ref: https://is.docs.wso2.com/en/latest/deploy/configure-email-sending/#configure-the-email-sender-globally
-      enabled: false
-      fromAddress: ""
-      username: ""
-      hostname: ""
-      port: 587
-      password: ""
-      enableStartTls: true
-      enableAuthentication: true
+     # -- Enable the email sender. Ref: https://is.docs.wso2.com/en/latest/deploy/configure-email-sending/#configure-the-email-sender-globally
+     enabled: false
+     fromAddress: ""
+     username: ""
+     hostname: ""
+     port: 587
+     password: ""
+     enableStartTls: true
+     enableAuthentication: true
   oauth:
     # -- Enable/Disable the scope authorization for all the OAuth clients. Ref: https://apim.docs.wso2.com/en/latest/api-security/key-management/third-party-key-managers/configure-wso2is7-connector/
     authorizeAllScopes: false
@@ -457,51 +450,12 @@ deploymentToml:
           # -- Enabling SSL protocols in the HTTPS transport. Ref: https://is.docs.wso2.com/en/latest/deploy/security/configure-transport-level-security/#enabling-ssl-protocols-in-the-wso2-is
           protocols: "+TLSv1, +TLSv1.1, +TLSv1.2, +TLSv1.3"
           # -- Configure TSL ciphers in the HTTPS transport. Ref: https://is.docs.wso2.com/en/latest/deploy/security/configure-transport-level-security/#disable-weak-ciphers
-          ciphers: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-            TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-            TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-            TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384,
-            TLS_DHE_DSS_WITH_AES_256_GCM_SHA384,
-            TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384,
-            TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-            TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256,
-            TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256,
-            TLS_DHE_DSS_WITH_AES_128_GCM_SHA256,
-            TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,
-            TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384,
-            TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384,
-            TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
-            TLS_DHE_DSS_WITH_AES_256_CBC_SHA256,
-            TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-            TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA,
-            TLS_ECDH_RSA_WITH_AES_256_CBC_SHA, TLS_DHE_DSS_WITH_AES_256_CBC_SHA,
-            TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
-            TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256,
-            TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256,
-            TLS_DHE_DSS_WITH_AES_128_CBC_SHA256,
-            TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-            TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA,
-            TLS_ECDH_RSA_WITH_AES_128_CBC_SHA, TLS_DHE_DSS_WITH_AES_128_CBC_SHA,
-            TLS_EMPTY_RENEGOTIATION_INFO_SCSVF"
+          ciphers: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384, TLS_DHE_DSS_WITH_AES_256_GCM_SHA384, TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256, TLS_DHE_DSS_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, TLS_DHE_DSS_WITH_AES_256_CBC_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA, TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA, TLS_ECDH_RSA_WITH_AES_256_CBC_SHA, TLS_DHE_DSS_WITH_AES_256_CBC_SHA, TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256, TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256, TLS_DHE_DSS_WITH_AES_128_CBC_SHA256, TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA, TLS_ECDH_RSA_WITH_AES_128_CBC_SHA, TLS_DHE_DSS_WITH_AES_128_CBC_SHA, TLS_EMPTY_RENEGOTIATION_INFO_SCSVF"
     thrift:
       # -- Enabling SSL protocols in ThriftAuthenticationService. Ref: https://is.docs.wso2.com/en/latest/deploy/security/configure-transport-level-security/#enable-ssl-protocols-and-ciphers-in-thriftauthenticationservice
       protocols: "TLSv1,TLSv1.1,TLSv1.2"
       # -- Configure TSL ciphers in ThriftAuthenticationService. Ref: https://is.docs.wso2.com/en/latest/deploy/security/configure-transport-level-security/#enable-ssl-protocols-and-ciphers-in-thriftauthenticationservice
-      ciphers: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_\
-        GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDH_ECDSA_WITH_AE\
-        S_256_GCM_SHA384,TLS_DHE_DSS_WITH_AES_256_GCM_SHA384,TLS_ECDH_RSA_WITH_\
-        AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDH_ECDSA\
-        _WITH_AES_128_GCM_SHA256,TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_D\
-        SS_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_\
-        ECDH_ECDSA_WITH_AES_256_CBC_SHA384,TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384\
-        ,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_DHE_DSS_WITH_AES_256_CBC_SHA\
-        256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDH_ECDSA_WITH_AES_256_CB\
-        C_SHA,TLS_ECDH_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_DSS_WITH_AES_256_CBC_SH\
-        A,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDH_ECDSA_WITH_AES_128_C\
-        BC_SHA256,TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_DSS_WITH_AES_128\
-        _CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDH_ECDSA_WITH_AE\
-        S_128_CBC_SHA,TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_DSS_WITH_AES_12\
-        8_CBC_SHA"
+      ciphers: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384,TLS_DHE_DSS_WITH_AES_256_GCM_SHA384,TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_DSS_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384,TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_DHE_DSS_WITH_AES_256_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDH_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_DSS_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_DSS_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_DSS_WITH_AES_128_CBC_SHA"
   userAccountLock:
     # -- Enable user account lock. Ref: https://is.docs.wso2.com/en/latest/guides/identity-lifecycles/lock-account/
     enabled: true
@@ -533,7 +487,7 @@ deploymentToml:
       captureAndUpdateEmailAddress: true
       showEmailAddressInUI: true
       useEventHandlerBasedEmailSender: true
-      emailAddressRegex: "(?&lt;=.{1}).(?=.*@)"
+      emailAddressRegex: '(?&lt;=.{1}).(?=.*@)'
       tokenExpirationTime: 300000
       # -- Enable account locking by email OTP. Ref: https://is.docs.wso2.com/en/latest/guides/identity-lifecycles/lock-accounts-by-failed-otp-attempts/
       userAccountLockEnabled: false
@@ -574,11 +528,10 @@ deploymentToml:
     # -- Enable account locking by OTP. Ref: https://is.docs.wso2.com/en/latest/guides/identity-lifecycles/lock-accounts-by-failed-otp-attempts/
     userAccountLockEnabled: false
   # -- Add custom configurations to deployment.toml.
-  extraConfigs:
-    #|
+  extraConfigs: #|
     # [transport.https.properties]
     # proxyPort = 443
-    # -- K8s API versions for K8s kinds
+# -- K8s API versions for K8s kinds
 k8sKindAPIVersions:
   # -- K8s API version for kind Deployment
   deployment: "apps/v1"

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2024-2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -65,9 +65,9 @@ deployment:
         eks.amazonaws.com/role-arn: "null"
   image:
     # -- Container image registry host name
-    registry: "docker.wso2.com"
+    registry: "registry.wso2.com"
     # -- Container image repository name
-    repository: "wso2is"
+    repository: "wso2-is/is"
     # -- Container image digest
     digest: ""
     # -- Container image tag. Either "tag" or "digest" should defined
@@ -85,7 +85,7 @@ deployment:
   # -- Number of deployment replicas
   replicas: 1
   # -- Additional volumeMounts to the pods. All the configuration mounts should be done under the path "/home/wso2carbon/wso2-config-volume/"
-  extraVolumeMounts: [ ]
+  extraVolumeMounts: []
   #  - name: custom-property-file
   #    mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/custom-property-file.properties
   #    subPath: custom-property-file.properties
@@ -106,7 +106,7 @@ deployment:
     enableRunAsGroup: false
     seccompProfile:
       enabled: true
-    # --  Seccomp profile type
+      # --  Seccomp profile type
       type: "RuntimeDefault"
     seLinux:
       enabled: false
@@ -165,9 +165,11 @@ deployment:
       # -- JVM memory options
       memOpts: "-Xms2048m -Xmx2048m"
       # -- JVM parameters
-      javaOpts: -Djdk.tls.ephemeralDHKeySize=2048 -Djdk.tls.rejectClientInitiatedRenegotiation=true
+      javaOpts: -Djdk.tls.ephemeralDHKeySize=2048
+        -Djdk.tls.rejectClientInitiatedRenegotiation=true
         -Dhttpclient.hostnameVerifier=Strict -Djdk.tls.client.protocols=TLSv1.2
-        -Djava.util.prefs.systemRoot=/home/wso2carbon/.java -Djava.util.prefs.userRoot=/home/wso2carbon/.java/.userPrefs
+        -Djava.util.prefs.systemRoot=/home/wso2carbon/.java
+        -Djava.util.prefs.userRoot=/home/wso2carbon/.java/.userPrefs
   # -- Product version
   buildVersion: "7.2.0"
   # -- Product pack name
@@ -300,96 +302,101 @@ deploymentToml:
       # -- The database username
       username: "wso2carbon"
       # -- The database JDBC URL
-      url: "jdbc:h2:./repository/database/WSO2IDENTITY_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
+      url: "jdbc:h2:./repository/database/WSO2IDENTITY_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK\
+        _TIMEOUT=60000"
       # -- The password
       password: "wso2carbon"
       # -- The database JDBC driver
       driver: "org.h2.Driver"
       # -- The database pool options
       poolOptions:
-#        maxActive: "50"
-#        maxWait: "60000"
-#        minIdle: "10"
-#        validationInterval: "30000"
-#        defaultAutoCommit: true
-#        commitOnReturn: false
+        #        maxActive: "50"
+        #        maxWait: "60000"
+        #        minIdle: "10"
+        #        validationInterval: "30000"
+        #        defaultAutoCommit: true
+        #        commitOnReturn: false
     shared:
       # -- The SQL server type(ex: mysql, mssql)
       type: "h2"
       # -- The database username
       username: "wso2carbon"
       # -- The database JDBC URL
-      url: "jdbc:h2:./repository/database/WSO2SHARED_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
+      url: "jdbc:h2:./repository/database/WSO2SHARED_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_T\
+        IMEOUT=60000"
       # -- The database password
       password: "wso2carbon"
       # -- The database JDBC driver
       driver: "org.h2.Driver"
       # -- The database pool options
       poolOptions:
-#          maxActive: "50"
-#          maxWait: "60000"
-#          minIdle: "10"
-#          validationInterval: "30000"
-#          defaultAutoCommit: true
-#          commitOnReturn: false
+        #          maxActive: "50"
+        #          maxWait: "60000"
+        #          minIdle: "10"
+        #          validationInterval: "30000"
+        #          defaultAutoCommit: true
+        #          commitOnReturn: false
     user:
       # -- The SQL server type(ex: mysql, mssql)
       type: "h2"
       # -- The database username
       username: "wso2carbon"
       # -- The database JDBC URL
-      url: "jdbc:h2:./repository/database/WSO2SHARED_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
+      url: "jdbc:h2:./repository/database/WSO2SHARED_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_T\
+        IMEOUT=60000"
       # -- The database password
       password: "wso2carbon"
       # -- The database JDBC driver
       driver: "org.h2.Driver"
       # -- The database pool options
       poolOptions:
-#          maxActive: "50"
-#          maxWait: "60000"
-#          minIdle: "10"
-#          validationInterval: "30000"
-#          defaultAutoCommit: true
-#          commitOnReturn: false
+        #          maxActive: "50"
+        #          maxWait: "60000"
+        #          minIdle: "10"
+        #          validationInterval: "30000"
+        #          defaultAutoCommit: true
+        #          commitOnReturn: false
     consent:
       # -- The SQL server type(ex: mysql, mssql)
       type: "h2"
       # -- The database username
       username: "wso2carbon"
       # -- The database JDBC URL
-      url: "jdbc:h2:./repository/database/WSO2IDENTITY_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
+      url: "jdbc:h2:./repository/database/WSO2IDENTITY_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK\
+        _TIMEOUT=60000"
       # -- The database password
       password: "wso2carbon"
       # -- The database JDBC driver
       driver: "org.h2.Driver"
       # -- The database pool options
       poolOptions:
-#        maxActive: "80"
-#        maxWait: "60000"
-#        minIdle: "5"
-#        testOnBorrow: true
-#        validationQuery: "SELECT 1"
-#        validationInterval: "30000"
-#        defaultAutoCommit: false
+        #        maxActive: "80"
+        #        maxWait: "60000"
+        #        minIdle: "5"
+        #        testOnBorrow: true
+        #        validationQuery: "SELECT 1"
+        #        validationInterval: "30000"
+        #        defaultAutoCommit: false
     agentIdentity:
       # -- The SQL server type(ex: mysql, mssql)
       type: "h2"
       # -- The database username
       username: "wso2carbon"
       # -- The database JDBC URL
-      url: "jdbc:h2:./repository/database/WSO2AGENTIDENTITY_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000"
+      url: "jdbc:h2:./repository/database/WSO2AGENTIDENTITY_DB;DB_CLOSE_ON_EXIT=FALSE\
+        ;LOCK_TIMEOUT=60000"
       # -- The database password
       password: "wso2carbon"
       # -- The database JDBC driver
       driver: "org.h2.Driver"
       # -- The database pool options
       poolOptions:
-#        maxActive: "50"
-#        maxWait: "60000"
-#        minIdle: "10"
-#        validationInterval: "30000"
-#        defaultAutoCommit: true
-#        commitOnReturn: false
+        #        maxActive: "50"
+        #        maxWait: "60000"
+        #        minIdle: "10"
+        #        validationInterval: "30000"
+        #        defaultAutoCommit: true
+        #        commitOnReturn: false
   keystore:
     tls:
       fileName: "wso2carbon.p12"
@@ -422,15 +429,15 @@ deploymentToml:
     secretKey: ""
   outputAdapter:
     email:
-     # -- Enable the email sender. Ref: https://is.docs.wso2.com/en/latest/deploy/configure-email-sending/#configure-the-email-sender-globally
-     enabled: false
-     fromAddress: ""
-     username: ""
-     hostname: ""
-     port: 587
-     password: ""
-     enableStartTls: true
-     enableAuthentication: true
+      # -- Enable the email sender. Ref: https://is.docs.wso2.com/en/latest/deploy/configure-email-sending/#configure-the-email-sender-globally
+      enabled: false
+      fromAddress: ""
+      username: ""
+      hostname: ""
+      port: 587
+      password: ""
+      enableStartTls: true
+      enableAuthentication: true
   oauth:
     # -- Enable/Disable the scope authorization for all the OAuth clients. Ref: https://apim.docs.wso2.com/en/latest/api-security/key-management/third-party-key-managers/configure-wso2is7-connector/
     authorizeAllScopes: false
@@ -450,12 +457,51 @@ deploymentToml:
           # -- Enabling SSL protocols in the HTTPS transport. Ref: https://is.docs.wso2.com/en/latest/deploy/security/configure-transport-level-security/#enabling-ssl-protocols-in-the-wso2-is
           protocols: "+TLSv1, +TLSv1.1, +TLSv1.2, +TLSv1.3"
           # -- Configure TSL ciphers in the HTTPS transport. Ref: https://is.docs.wso2.com/en/latest/deploy/security/configure-transport-level-security/#disable-weak-ciphers
-          ciphers: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384, TLS_DHE_DSS_WITH_AES_256_GCM_SHA384, TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384, TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256, TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256, TLS_DHE_DSS_WITH_AES_128_GCM_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384, TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384, TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384, TLS_DHE_DSS_WITH_AES_256_CBC_SHA256, TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA, TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA, TLS_ECDH_RSA_WITH_AES_256_CBC_SHA, TLS_DHE_DSS_WITH_AES_256_CBC_SHA, TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256, TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256, TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256, TLS_DHE_DSS_WITH_AES_128_CBC_SHA256, TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA, TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA, TLS_ECDH_RSA_WITH_AES_128_CBC_SHA, TLS_DHE_DSS_WITH_AES_128_CBC_SHA, TLS_EMPTY_RENEGOTIATION_INFO_SCSVF"
+          ciphers: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+            TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+            TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+            TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384,
+            TLS_DHE_DSS_WITH_AES_256_GCM_SHA384,
+            TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384,
+            TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256,
+            TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256,
+            TLS_DHE_DSS_WITH_AES_128_GCM_SHA256,
+            TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,
+            TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384,
+            TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384,
+            TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
+            TLS_DHE_DSS_WITH_AES_256_CBC_SHA256,
+            TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+            TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA,
+            TLS_ECDH_RSA_WITH_AES_256_CBC_SHA, TLS_DHE_DSS_WITH_AES_256_CBC_SHA,
+            TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+            TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256,
+            TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256,
+            TLS_DHE_DSS_WITH_AES_128_CBC_SHA256,
+            TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+            TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA,
+            TLS_ECDH_RSA_WITH_AES_128_CBC_SHA, TLS_DHE_DSS_WITH_AES_128_CBC_SHA,
+            TLS_EMPTY_RENEGOTIATION_INFO_SCSVF"
     thrift:
       # -- Enabling SSL protocols in ThriftAuthenticationService. Ref: https://is.docs.wso2.com/en/latest/deploy/security/configure-transport-level-security/#enable-ssl-protocols-and-ciphers-in-thriftauthenticationservice
       protocols: "TLSv1,TLSv1.1,TLSv1.2"
       # -- Configure TSL ciphers in ThriftAuthenticationService. Ref: https://is.docs.wso2.com/en/latest/deploy/security/configure-transport-level-security/#enable-ssl-protocols-and-ciphers-in-thriftauthenticationservice
-      ciphers: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384,TLS_DHE_DSS_WITH_AES_256_GCM_SHA384,TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_DSS_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384,TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_DHE_DSS_WITH_AES_256_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDH_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_DSS_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_DSS_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_DSS_WITH_AES_128_CBC_SHA"
+      ciphers: "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_\
+        GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDH_ECDSA_WITH_AE\
+        S_256_GCM_SHA384,TLS_DHE_DSS_WITH_AES_256_GCM_SHA384,TLS_ECDH_RSA_WITH_\
+        AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDH_ECDSA\
+        _WITH_AES_128_GCM_SHA256,TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256,TLS_DHE_D\
+        SS_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384,TLS_\
+        ECDH_ECDSA_WITH_AES_256_CBC_SHA384,TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384\
+        ,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,TLS_DHE_DSS_WITH_AES_256_CBC_SHA\
+        256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDH_ECDSA_WITH_AES_256_CB\
+        C_SHA,TLS_ECDH_RSA_WITH_AES_256_CBC_SHA,TLS_DHE_DSS_WITH_AES_256_CBC_SH\
+        A,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDH_ECDSA_WITH_AES_128_C\
+        BC_SHA256,TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256,TLS_DHE_DSS_WITH_AES_128\
+        _CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDH_ECDSA_WITH_AE\
+        S_128_CBC_SHA,TLS_ECDH_RSA_WITH_AES_128_CBC_SHA,TLS_DHE_DSS_WITH_AES_12\
+        8_CBC_SHA"
   userAccountLock:
     # -- Enable user account lock. Ref: https://is.docs.wso2.com/en/latest/guides/identity-lifecycles/lock-account/
     enabled: true
@@ -487,7 +533,7 @@ deploymentToml:
       captureAndUpdateEmailAddress: true
       showEmailAddressInUI: true
       useEventHandlerBasedEmailSender: true
-      emailAddressRegex: '(?&lt;=.{1}).(?=.*@)'
+      emailAddressRegex: "(?&lt;=.{1}).(?=.*@)"
       tokenExpirationTime: 300000
       # -- Enable account locking by email OTP. Ref: https://is.docs.wso2.com/en/latest/guides/identity-lifecycles/lock-accounts-by-failed-otp-attempts/
       userAccountLockEnabled: false
@@ -528,10 +574,11 @@ deploymentToml:
     # -- Enable account locking by OTP. Ref: https://is.docs.wso2.com/en/latest/guides/identity-lifecycles/lock-accounts-by-failed-otp-attempts/
     userAccountLockEnabled: false
   # -- Add custom configurations to deployment.toml.
-  extraConfigs: #|
+  extraConfigs:
+    #|
     # [transport.https.properties]
     # proxyPort = 443
-# -- K8s API versions for K8s kinds
+    # -- K8s API versions for K8s kinds
 k8sKindAPIVersions:
   # -- K8s API version for kind Deployment
   deployment: "apps/v1"

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2024-2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except


### PR DESCRIPTION
## Purpose

This pull request updates documentation and configuration to support the new WSO2 Container Registry (`registry.wso2.com`) and registry token authentication for WSO2 Support users. It also updates default image registry and repository values throughout the Helm chart and documentation.

**WSO2 Registry Access and Authentication:**

* Added a new section in `README.md` explaining how WSO2 Support users should generate a registry token, authenticate to `registry.wso2.com`, and create a Kubernetes image pull secret.
* Added instructions to installation sections in `README.md` for WSO2 Support users, detailing how to set the registry and image pull secret in Helm install commands. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R119-R124) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R149-R154)

**Default Registry and Repository Updates:**

* Changed the default image registry from `docker.wso2.com` to `registry.wso2.com` and the repository from `wso2is` to `wso2-is/is` in `values.yaml`, `README.md`, and `templates/secret-image-pull.yaml`. [[1]](diffhunk://#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7eL68-R70) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L488-R527) [[3]](diffhunk://#diff-d8455833b620285036a260850e42b22e94a28c41846b9396650a6dd8b52fa110L21-R21)

**Legal Notice Update:**

* Updated copyright years in `templates/secret-image-pull.yaml`.