### PR TITLE
[7.1.x] Update registry reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,32 @@ ___
 ### Security
 - AppArmor Security Module enabled
 
+### WSO2 Registry Access (for WSO2 Support users)
+
+If you are using WSO2 Support images from the WSO2 Container Registry (`registry.wso2.com`), you must authenticate using a registry token — WSO2 account credentials can no longer be used directly for CLI access.
+
+**Generate a Token:**
+1. Log in to the [WSO2 Support Portal](https://support.wso2.com).
+2. Navigate to **Projects > My Projects > Registry Tokens**.
+3. Click **Generate Token** and provide a descriptive name (e.g., `k8s-deployment-token`).
+4. **Important:** Copy the **Token ID** and **Token Secret** immediately — the secret is shown only once.
+
+For more details, refer to the [WSO2 Registry CLI Access documentation](https://updates.docs.wso2.com/en/latest/updates/wso2-registry-cli-access/).
+
+**Log in to the WSO2 Registry:**
+```shell
+docker login registry.wso2.com -u <Token_ID> -p <Token_Secret>
+```
+
+**Create a Kubernetes image pull secret** so that your cluster can pull images from the registry:
+```shell
+kubectl create secret docker-registry wso2-registry-credentials \
+  --docker-server=registry.wso2.com \
+  --docker-username=<Token_ID> \
+  --docker-password=<Token_Secret> \
+  -n $NAMESPACE
+```
+
 ### Tools
 | Tool          | Installation Guide | Version Check Command |
 |---------------|--------------------|-----------------------|
@@ -90,6 +116,12 @@ There are two ways to install the WSO2 Identity Server using the Helm chart.
 
     **Note:** To disable AppArmor, set --set deployment.apparmor.enabled="false" (default: true)
 
+    > **WSO2 Support users:** If you are using images from the WSO2 Container Registry (`registry.wso2.com`) with WSO2 Support, you must authenticate using a registry token. See [Accessing Images via CLI](https://updates.docs.wso2.com/en/latest/updates/wso2-registry-cli-access/) for instructions on generating a token and creating an image pull secret. Then add the following to the install command:
+    > ```shell
+    > --set deployment.image.registry="registry.wso2.com" \
+    > --set deployment.image.imagePullSecret="wso2-registry-credentials"
+    > ```
+
 ### Option 2: Install the Chart from source
 
 If you prefer to build the chart from the source, follow the steps below:
@@ -113,6 +145,12 @@ If you prefer to build the chart from the source, follow the steps below:
     **Note:** 
     - To disable AppArmor, set --set deployment.apparmor.enabled="false" (default: true)
     - The above commands use the publicly released [WSO2 Identity Server Docker image](https://hub.docker.com/r/wso2/wso2is). To use a custom docker image, update the registry, repository, and tag accordingly. You can also specify an image digest instead of a tag as shown below:
+
+    > **WSO2 Support users:** If you are using images from the WSO2 Container Registry (`registry.wso2.com`) with WSO2 Support, you must authenticate using a registry token. See [Accessing Images via CLI](https://updates.docs.wso2.com/en/latest/updates/wso2-registry-cli-access/) for instructions on generating a token and creating an image pull secret. Then add the following to the install command:
+    > ```shell
+    > --set deployment.image.registry="registry.wso2.com" \
+    > --set deployment.image.imagePullSecret="wso2-registry-credentials"
+    > ```
     
         ```shell
         --set deployment.image.digest=<digest> 
@@ -478,8 +516,8 @@ helm install "$RELEASE_NAME" wso2/identity-server --version 7.1.0-1  -n "$NAMESP
 | deployment.image.digest | string | `""` | Container image digest |
 | deployment.image.imagePullSecret | string | `""` | image pull secret name |
 | deployment.image.pullPolicy | string | `"Always"` | Refer to the Kubernetes documentation on updating images (Ref: https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
-| deployment.image.registry | string | `"docker.wso2.com"` | Container image registry host name |
-| deployment.image.repository | string | `"wso2is"` | Container image repository name |
+| deployment.image.registry | string | `"registry.wso2.com"` | Container image registry host name |
+| deployment.image.repository | string | `"wso2-is/is"` | Container image repository name |
 | deployment.image.tag | string | `"7.1.0"` | Container image tag. Either "tag" or "digest" should defined |
 | deployment.ingress.annotations."nginx.ingress.kubernetes.io/affinity" | string | `"cookie"` |  |
 | deployment.ingress.annotations."nginx.ingress.kubernetes.io/backend-protocol" | string | `"HTTPS"` |  |

--- a/templates/secret-image-pull.yaml
+++ b/templates/secret-image-pull.yaml
@@ -1,5 +1,5 @@
 {{ if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
-# Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2024-2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -18,7 +18,7 @@
 {{- $username := .Values.wso2.subscription.username }}
 {{- $password := .Values.wso2.subscription.password }}
 {{- $email := .Values.wso2.subscription.username }}
-{{- $regId := "docker.wso2.com" }}
+{{- $regId := "registry.wso2.com" }}
 {{- $auth := printf "%s:%s" $username $password | b64enc }}
 {{- $files := .Files }}
 

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2025, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+# Copyright (c) 2024-2026, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
 #
 # WSO2 LLC. licenses this file to you under the Apache License,
 # Version 2.0 (the "License"); you may not use this file except
@@ -53,9 +53,9 @@ deployment:
 
   image:
     # -- Container image registry host name
-    registry: "docker.wso2.com"
+    registry: "registry.wso2.com"
     # -- Container image repository name
-    repository: "wso2is"
+    repository: "wso2-is/is"
     # -- Container image digest
     digest: ""
     # -- Container image tag. Either "tag" or "digest" should defined


### PR DESCRIPTION
## Purpose
This pull request updates the documentation and configuration to support the new WSO2 Container Registry (`registry.wso2.com`) for image access, especially for WSO2 Support users. It also updates copyright years.

**WSO2 Registry Access and Image Configuration**

* Updated documentation in `README.md` to instruct WSO2 Support users to use registry tokens for authenticating with `registry.wso2.com`, including detailed steps for generating a token, logging in, and creating Kubernetes image pull secrets.
* Added install command instructions for WSO2 Support users to specify the new registry and image pull secret when deploying via Helm. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R119-R124) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R149-R154)
* Changed default image registry and repository values from `docker.wso2.com`/`wso2is` to `registry.wso2.com`/`wso2-is/is` in `values.yaml`, `templates/secret-image-pull.yaml`, and the Helm values table in `README.md`. [[1]](diffhunk://#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7eL56-R58) [[2]](diffhunk://#diff-d8455833b620285036a260850e42b22e94a28c41846b9396650a6dd8b52fa110L21-R21) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L481-R520)
* Updated the registry host in the image pull secret template to match the new registry.

**Other Updates**

* Updated copyright years in `values.yaml` and `templates/secret-image-pull.yaml`. [[1]](diffhunk://#diff-8377b3e3740a3fcd9f682e5fb55425f2fdbece1791854b9e5013e7f1a5e60e7eL1-R1) [[2]](diffhunk://#diff-d8455833b620285036a260850e42b22e94a28c41846b9396650a6dd8b52fa110L2-R2)