### PR TITLE
[7.3.0] Fix imagePullSecret reference in deployment.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [v7.3.0-2] - 2026-07-03
+
+### Changed
+
+- Corrected the `imagePullSecrets` reference in `deployment.yaml` to use `.Values.deployment.image.imagePullSecret` instead of the non-existent `.Values.wso2.deployment.image.imagePullSecret`, ensuring the configured image pull secret is applied correctly.
+
 ## [v7.3.0-1] - 2026-05-19
 
 ### Added

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -18,5 +18,5 @@ apiVersion: v2
 name: identity-server
 description: A Helm chart for WSO2 Identity server
 type: application
-version: 7.3.0-1
+version: 7.3.0-2
 appVersion: "7.3.0"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -246,7 +246,7 @@ spec:
       serviceAccountName: {{ template "..fullname" . }}
       {{- if .Values.deployment.image.imagePullSecret }}
       imagePullSecrets:
-        - name: {{ .Values.wso2.deployment.image.imagePullSecret }}
+        - name: {{ .Values.deployment.image.imagePullSecret }}
       {{- else if and (not (eq .Values.wso2.subscription.username "")) (not (eq .Values.wso2.subscription.password "")) }}
       imagePullSecrets:
         - name: {{ template "..fullname" . }}-wso2-private-registry-creds


### PR DESCRIPTION
## Purpose

This pull request updates the Helm chart for WSO2 Identity Server to version `7.3.0-2` and corrects the configuration for image pull secrets in the deployment template. The most important changes are:

Helm Chart Version Update:
* Updated the chart version in `Chart.yaml` from `7.3.0-1` to `7.3.0-2` to reflect the new release.

Deployment Template Fixes:
* Fixed the `imagePullSecrets` reference in `deployment.yaml` to use `.Values.deployment.image.imagePullSecret` instead of the incorrect `.Values.wso2.deployment.image.imagePullSecret`, ensuring the correct image pull secret is used during deployment.

Documentation:
* Added a new changelog entry in `CHANGELOG.md` for version `v7.3.0-2`, documenting the correction to the `imagePullSecrets` reference in the deployment template.

## Related PR

- https://github.com/wso2/kubernetes-is/pull/352/changes